### PR TITLE
Resetting rust analyzer settings to default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,9 +8,6 @@
     "[markdown]": {
         "editor.defaultFormatter": null
     },
-    "[rust]": {
-        "editor.inlayHints.enabled": "on",
-    },
     "rust-analyzer.rustfmt.extraArgs": [
         "--config",
         "max_width=100"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
         "editor.defaultFormatter": null
     },
     "[rust]": {
-        "editor.inlayHints.enabled": "off",
+        "editor.inlayHints.enabled": "on",
     },
     "rust-analyzer.rustfmt.extraArgs": [
         "--config",


### PR DESCRIPTION
@guzman-raphael I found the issue I was mentioning yesterday where the hints were not showing up. I think we should just leave it by default, and you can disable it on your side. There might be other people out there like me who been using it as a default then all of the sudden it is missing, then have to go look for this setting.