### PR TITLE
Improve error handling + docs

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,5 +1,5 @@
 excessive-nesting-threshold = 3
 too-many-arguments-threshold = 10
-allowed-prefixes = ["..", "GPU"]
+allowed-prefixes = ["..", "GPU", "Orca"]
 min-ident-chars-threshold = 2
 allowed-idents-below-min-chars = ["..", "k", "f", "re", "id"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ indoc = "2.0.5"
 
 [lints.rust]
 non_ascii_idents = "deny"
-# missing_docs = "warn"     # temporary: add once we have docs
+missing_docs = "warn"
 
 [lints.clippy]
 correctness = "deny"
@@ -96,6 +96,5 @@ todo = { level = "warn", priority = 127 }                              # warn to
 use_debug = { level = "warn", priority = 127 }                         # debug print
 
 # temporary
-missing_errors_doc = { level = "allow", priority = 127 }        # remove once we have docs
 single_call_fn = { level = "allow", priority = 127 }            # remove once other models are in
 tests_outside_test_module = { level = "allow", priority = 127 } # for now due to false-positive for integration tests: https://github.com/rust-lang/rust-clippy/pull/13038

--- a/README.md
+++ b/README.md
@@ -7,7 +7,14 @@
 set -e                                    # stop early on non-zero exit
 cargo clippy --all-targets -- -D warnings # syntax and style tests
 cargo fmt --check                         # formatting test
-cargo llvm-cov -- --nocapture             # integration tests w/ coverage report
+cargo llvm-cov -- --nocapture             # integration tests w/ coverage summary
+cargo llvm-cov --html -- --nocapture      # integration tests w/ coverage report (target/llvm-cov/html/index.html)
+```
+
+## Docs
+
+```bash
+cargo doc --no-deps                       # gen api docs (target/doc/orcapod/index.html)
 ```
 
 ## Project Management

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use colored::Colorize;
 use glob;
 use regex;
 use serde_yaml;
@@ -61,10 +62,18 @@ impl Display for OrcaError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match &self.0 {
             Kind::FileExists(path) => {
-                write!(f, "File `{}` already exists.", path.to_string_lossy())
+                write!(
+                    f,
+                    "File `{}` already exists.",
+                    path.to_string_lossy().bright_cyan()
+                )
             }
             Kind::FileHasNoParent(path) => {
-                write!(f, "File `{}` has no parent.", path.to_string_lossy())
+                write!(
+                    f,
+                    "File `{}` has no parent.",
+                    path.to_string_lossy().bright_red()
+                )
             }
             Kind::NoAnnotationFound(class, name, version) => {
                 write!(f, "No annotation found for `{name}:{version}` {class}.")

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,9 +7,10 @@ use std::{
     fmt::{Display, Formatter},
     io,
     path::PathBuf,
+    result,
 };
 /// Shorthand for a Result that returns an `OrcaError`.
-pub type OrcaResult<T> = Result<T, OrcaError>;
+pub type Result<T> = result::Result<T, OrcaError>;
 /// Possiable errors you may encounter.
 #[derive(Debug)]
 pub enum OrcaError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
-use colored::Colorize;
+use glob;
+use regex;
 use serde_yaml;
 use std::{
     error::Error,
@@ -8,122 +9,66 @@ use std::{
     path::PathBuf,
 };
 
-/// Wrapper around `serde_yaml::from_str`
+pub type OrcaResult<T> = Result<T, OrcaError>;
+
 #[derive(Debug)]
-pub struct DeserializeFailure {
-    pub path: PathBuf,
-    pub error: serde_yaml::Error,
+pub enum OrcaError {
+    FileExists(PathBuf),
+    FileHasNoParent(PathBuf),
+    NoAnnotationFound(String, String, String),
+    NoRegexMatch,
+    GlobError(glob::GlobError),
+    GlobPaternError(glob::PatternError),
+    RegexError(regex::Error),
+    SerdeYamlError(serde_yaml::Error),
+    IoError(io::Error),
 }
-impl Error for DeserializeFailure {}
-impl Display for DeserializeFailure {
+impl Error for OrcaError {}
+impl Display for OrcaError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}{}{}{}",
-            "Failed to deserialize with error ".bright_red(),
-            self.error.to_string().bright_red(),
-            " for ".bright_red(),
-            self.path.to_string_lossy().bright_cyan()
-        )
+        match self {
+            Self::FileExists(path) => {
+                write!(f, "File `{}` already exists.", path.to_string_lossy())
+            }
+            Self::FileHasNoParent(path) => {
+                write!(f, "File `{}` has no parent.", path.to_string_lossy())
+            }
+            Self::NoAnnotationFound(class, name, version) => {
+                write!(f, "No annotation found for `{name}:{version}` {class}.")
+            }
+            Self::NoRegexMatch => {
+                write!(f, "No match for regex.")
+            }
+            Self::GlobError(error) => write!(f, "{error}"),
+            Self::GlobPaternError(error) => write!(f, "{error}"),
+            Self::SerdeYamlError(error) => write!(f, "{error}"),
+            Self::RegexError(error) => write!(f, "{error}"),
+            Self::IoError(error) => write!(f, "{error}"),
+        }
     }
 }
-
-/// Wrapper around getting None when trying to find parent
-#[derive(Debug)]
-pub struct FileHasNoParent {
-    pub path: PathBuf,
-}
-impl Error for FileHasNoParent {}
-impl Display for FileHasNoParent {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "File `{}` has no parent.",
-            self.path.to_string_lossy().bright_red()
-        )
+impl From<glob::GlobError> for OrcaError {
+    fn from(error: glob::GlobError) -> Self {
+        Self::GlobError(error)
     }
 }
-
-/// Wrapper around `serde_yaml::to_string`
-#[derive(Debug)]
-pub struct SerializeFailure {
-    pub item_debug_string: String,
-    pub error: serde_yaml::Error,
-}
-impl Error for SerializeFailure {}
-impl Display for SerializeFailure {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}{}{}{}",
-            "Failed to seralize ".bright_red(),
-            self.item_debug_string.bright_cyan(),
-            " with error  ".bright_red(),
-            self.error.to_string().bright_red(),
-        )
+impl From<glob::PatternError> for OrcaError {
+    fn from(error: glob::PatternError) -> Self {
+        Self::GlobPaternError(error)
     }
 }
-
-/// Wrapper around `fs::read_to_string` and `fs::write`
-#[derive(Debug)]
-pub struct IOFailure {
-    pub path: PathBuf,
-    pub error: io::Error,
-}
-impl Error for IOFailure {}
-impl Display for IOFailure {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}{}{}{}",
-            "IO Error: ".bright_red(),
-            &self.error.to_string().bright_red(),
-            " at ".bright_red(),
-            &self.path.to_string_lossy().cyan(),
-        )
+impl From<serde_yaml::Error> for OrcaError {
+    fn from(error: serde_yaml::Error) -> Self {
+        Self::SerdeYamlError(error)
     }
 }
-
-/// Raise error when file exists but unexpected
-#[derive(Debug)]
-pub struct FileExists {
-    pub path: PathBuf,
-}
-impl Error for FileExists {}
-impl Display for FileExists {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "File `{}` already exists.",
-            self.path.to_string_lossy().bright_red()
-        )
+impl From<regex::Error> for OrcaError {
+    fn from(error: regex::Error) -> Self {
+        Self::RegexError(error)
     }
 }
-
-/// Raise error when glob doesn't match on an annotation
-#[derive(Debug)]
-pub struct NoAnnotationFound {
-    pub class: String,
-    pub name: String,
-    pub version: String,
-}
-impl Error for NoAnnotationFound {}
-impl Display for NoAnnotationFound {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "No annotation found for `{}:{}` {}.",
-            self.name, self.version, self.class
-        )
-    }
-}
-
-/// Raise error when regex doesn't match
-#[derive(Debug)]
-pub struct NoRegexMatch;
-impl Error for NoRegexMatch {}
-impl Display for NoRegexMatch {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "No match for regex.")
+impl From<io::Error> for OrcaError {
+    fn from(error: io::Error) -> Self {
+        Self::IoError(error)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,19 +8,28 @@ use std::{
     io,
     path::PathBuf,
 };
-
+/// Shorthand for a Result that returns an `OrcaError`.
 pub type OrcaResult<T> = Result<T, OrcaError>;
-
+/// Possiable errors you may encounter.
 #[derive(Debug)]
 pub enum OrcaError {
+    /// Returned if a file is not expected to exist.
     FileExists(PathBuf),
+    /// Returned if a file is expected to have a parent.
     FileHasNoParent(PathBuf),
+    /// Returned if an annotation was expected to exist.
     NoAnnotationFound(String, String, String),
+    /// Returned if a regular expression was expected to match.
     NoRegexMatch,
+    /// Wrapper around `glob::GlobError`
     GlobError(glob::GlobError),
+    /// Wrapper around `glob::PatternError`
     GlobPaternError(glob::PatternError),
+    /// Wrapper around `regex::Error`
     RegexError(regex::Error),
+    /// Wrapper around `serde_yaml::Error`
     SerdeYamlError(serde_yaml::Error),
+    /// Wrapper around `io::Error`
     IoError(io::Error),
 }
 impl Error for OrcaError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
+//! Intuitive compute pipeline orchestration with reproducibility, performance, and scalability in
+//! mind.
+
+/// Error handling based on enumeration.
 pub mod error;
+/// Components of the data model.
 pub mod model;
+/// Data persistence is provided by using a store backend.
 pub mod store;
 mod util;

--- a/src/model.rs
+++ b/src/model.rs
@@ -10,7 +10,7 @@ use std::{
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
 };
-
+/// Converts a model instance into a consistent yaml.
 pub fn to_yaml<T: Serialize>(instance: &T) -> OrcaResult<String> {
     let mapping: BTreeMap<String, Value> = serde_yaml::from_str(&serde_yaml::to_string(instance)?)?; // sort
     let mut yaml = serde_yaml::to_string(
@@ -23,7 +23,7 @@ pub fn to_yaml<T: Serialize>(instance: &T) -> OrcaResult<String> {
 
     Ok(yaml)
 }
-
+/// Instantiates a model from from yaml content and its unique hash.
 pub fn from_yaml<T: DeserializeOwned>(
     annotation_file: &Path,
     spec_file: &Path,
@@ -46,9 +46,12 @@ pub fn from_yaml<T: DeserializeOwned>(
 
 // --- core model structs ---
 
+/// A reusable, containerized computational unit.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Pod {
+    /// Metadata that doesn't affect reproducibility.
     pub annotation: Annotation,
+    /// Unique id based on reproducibility.
     pub hash: String,
     source_commit_url: String,
     image: String,
@@ -62,6 +65,7 @@ pub struct Pod {
 }
 
 impl Pod {
+    /// Construct a new pod instance.
     pub fn new(
         annotation: Annotation,
         source_commit_url: String,
@@ -96,28 +100,40 @@ impl Pod {
 
 // --- util types ---
 
+/// Standard metadata structure for all model instances.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Annotation {
+    /// A unique name.
     pub name: String,
+    /// A unique semantic version.
     pub version: String,
+    /// A long form description.
     pub description: String,
 }
-
+/// Specification for GPU requirements in computation.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GPURequirement {
+    /// GPU model specification.
     pub model: GPUModel,
+    /// Manufacturer recommended memory.
     pub recommended_memory: u64,
+    /// Number of GPU cards required.
     pub count: u16,
 }
-
+/// GPU model specification.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum GPUModel {
-    NVIDIA(String), // String will be the specific model of the gpu
+    /// NVIDIA-manufactured card where `String` is the specific model e.g. ???
+    NVIDIA(String),
+    /// AMD-manufactured card where `String` is the specific model e.g. ???
     AMD(String),
 }
-
+/// Streams are named and represent an abstration for the file(s) that represent some particular
+/// data.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StreamInfo {
+    /// Path to stream file.
     pub path: PathBuf,
+    /// Naming pattern for the stream.
     pub match_pattern: String,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,7 @@
-use crate::util::{get_type_name, hash};
+use crate::{
+    error::NoRegexMatch,
+    util::{get_type_name, hash},
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_yaml::{Mapping, Value};
 use std::{
@@ -9,7 +12,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub fn to_yaml<T: Serialize>(instance: &T) -> Result<String, Box<dyn Error>> {
+pub fn to_yaml<T: Serialize>(instance: &T) -> Result<String, NoRegexMatch> {
     let mapping: BTreeMap<String, Value> = serde_yaml::from_str(&serde_yaml::to_string(instance)?)?; // sort
     let mut yaml = serde_yaml::to_string(
         &mapping
@@ -26,7 +29,7 @@ pub fn from_yaml<T: DeserializeOwned>(
     annotation_file: &Path,
     spec_file: &Path,
     hash: &str,
-) -> Result<T, Box<dyn Error>> {
+) -> Result<T, NoRegexMatch> {
     let annotation: Mapping = serde_yaml::from_str(&fs::read_to_string(annotation_file)?)?;
     let spec_yaml = BufReader::new(fs::File::open(spec_file)?)
         .lines()
@@ -71,7 +74,7 @@ impl Pod {
         recommended_cpus: f32,
         recommended_memory: u64,
         required_gpu: Option<GPURequirement>,
-    ) -> Result<Self, Box<dyn Error>> {
+    ) -> Result<Self, NoRegexMatch> {
         let pod_no_hash = Self {
             annotation,
             hash: String::new(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,18 +1,17 @@
 use crate::{
-    error::NoRegexMatch,
+    error::OrcaResult,
     util::{get_type_name, hash},
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_yaml::{Mapping, Value};
 use std::{
     collections::BTreeMap,
-    error::Error,
     fs,
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
 };
 
-pub fn to_yaml<T: Serialize>(instance: &T) -> Result<String, NoRegexMatch> {
+pub fn to_yaml<T: Serialize>(instance: &T) -> OrcaResult<String> {
     let mapping: BTreeMap<String, Value> = serde_yaml::from_str(&serde_yaml::to_string(instance)?)?; // sort
     let mut yaml = serde_yaml::to_string(
         &mapping
@@ -29,7 +28,7 @@ pub fn from_yaml<T: DeserializeOwned>(
     annotation_file: &Path,
     spec_file: &Path,
     hash: &str,
-) -> Result<T, NoRegexMatch> {
+) -> OrcaResult<T> {
     let annotation: Mapping = serde_yaml::from_str(&fs::read_to_string(annotation_file)?)?;
     let spec_yaml = BufReader::new(fs::File::open(spec_file)?)
         .lines()
@@ -74,7 +73,7 @@ impl Pod {
         recommended_cpus: f32,
         recommended_memory: u64,
         required_gpu: Option<GPURequirement>,
-    ) -> Result<Self, NoRegexMatch> {
+    ) -> OrcaResult<Self> {
         let pod_no_hash = Self {
             annotation,
             hash: String::new(),

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -48,7 +48,7 @@ impl Store for LocalFileStore {
             Self::parse_annotation_path(&self.make_annotation_path("pod", "*", name, version))?
                 .next()
                 .ok_or_else(|| {
-                    OrcaError::NoAnnotationFound(class, name.to_owned(), version.to_owned())
+                    OrcaError::no_annotation_found(class, name.to_owned(), version.to_owned())
                 })??;
 
         from_yaml::<Pod>(
@@ -75,17 +75,17 @@ impl Store for LocalFileStore {
         let class = "pod".to_owned();
         let versions = self.get_pod_version_map(name)?;
         let hash = versions.get(version).ok_or_else(|| {
-            OrcaError::NoAnnotationFound(class, name.to_owned(), version.to_owned())
+            OrcaError::no_annotation_found(class, name.to_owned(), version.to_owned())
         })?;
 
         let annotation_file = self.make_annotation_path("pod", hash, name, version);
         let annotation_dir = annotation_file
             .parent()
-            .ok_or_else(|| OrcaError::FileHasNoParent(annotation_file.clone()))?;
+            .ok_or_else(|| OrcaError::file_has_no_parent(annotation_file.clone()))?;
         let spec_file = self.make_spec_path("pod", hash);
         let spec_dir = spec_file
             .parent()
-            .ok_or_else(|| OrcaError::FileHasNoParent(spec_file.clone()))?;
+            .ok_or_else(|| OrcaError::file_has_no_parent(spec_file.clone()))?;
 
         fs::remove_file(&annotation_file)?;
         if !versions
@@ -159,7 +159,7 @@ impl LocalFileStore {
             let filepath_string = String::from(filepath?.to_string_lossy());
             let group = re
                 .captures(&filepath_string)
-                .ok_or_else(|| OrcaError::NoRegexMatch)?;
+                .ok_or_else(OrcaError::no_regex_match)?;
             Ok((
                 group["name"].to_string(),
                 (group["hash"].to_string(), group["version"].to_string()),
@@ -185,7 +185,7 @@ impl LocalFileStore {
         }
         let file_exists = file.exists();
         if file_exists && fail_if_exists {
-            return Err(OrcaError::FileExists(file.to_path_buf()));
+            return Err(OrcaError::file_exists(file.to_path_buf()));
         } else if file_exists {
             println!(
                 "Skip saving `{}` since it is already stored.",

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -10,16 +10,16 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
-
+/// Support for a storage backend on a local filesystem directory.
 #[derive(Debug)]
 pub struct LocalFileStore {
+    /// A local path to a directory where store will be located.
     pub directory: PathBuf,
 }
 
 impl Store for LocalFileStore {
     fn save_pod(&self, pod: &Pod) -> OrcaResult<()> {
         let class = "pod";
-
         // Save the annotation file and throw and error if exist
         Self::save_file(
             &self.make_annotation_path(
@@ -31,7 +31,6 @@ impl Store for LocalFileStore {
             &serde_yaml::to_string(&pod.annotation)?,
             true,
         )?;
-
         // Save the pod and skip if it already exist, for the case of many annotation to a single pod
         Self::save_file(
             &self.make_spec_path(class, &pod.hash),
@@ -107,12 +106,13 @@ impl Store for LocalFileStore {
 }
 
 impl LocalFileStore {
+    /// Construct a local file store instance.
     pub fn new(directory: impl Into<PathBuf>) -> Self {
         Self {
             directory: directory.into(),
         }
     }
-
+    /// Path where annotation file is located.
     pub fn make_annotation_path(
         &self,
         class: &str,
@@ -130,7 +130,7 @@ impl LocalFileStore {
             version,
         ))
     }
-
+    /// Path where specification file is located.
     pub fn make_spec_path(&self, class: &str, hash: &str) -> PathBuf {
         PathBuf::from(format!(
             "{}/{}/{}/{}",

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -179,7 +179,7 @@ impl LocalFileStore {
             .collect::<Result<BTreeMap<String, String>, _>>()
     }
 
-    pub fn save_file(file: &Path, content: &str, fail_if_exists: bool) -> OrcaResult<()> {
+    fn save_file(file: &Path, content: &str, fail_if_exists: bool) -> OrcaResult<()> {
         if let Some(parent) = file.parent() {
             fs::create_dir_all(parent)?;
         }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,16 +1,34 @@
-use crate::{error::OrcaResult, model::Pod};
+use crate::{error::Result, model::Pod};
 use std::collections::BTreeMap;
 
 /// Standard behavior of any store backend supported.
 pub trait Store {
     /// How a pod is stored.
-    fn save_pod(&self, pod: &Pod) -> OrcaResult<()>;
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there is an issue storing `pod`.
+    fn save_pod(&self, pod: &Pod) -> Result<()>;
     /// How to load a stored pod into a model instance.
-    fn load_pod(&self, name: &str, version: &str) -> OrcaResult<Pod>;
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there is an issue loading a pod from the store using `name` and
+    /// `version`.
+    fn load_pod(&self, name: &str, version: &str) -> Result<Pod>;
     /// How to query stored pods.
-    fn list_pod(&self) -> OrcaResult<BTreeMap<String, Vec<String>>>;
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there is an issue querying metadata from existing pods in the store.
+    fn list_pod(&self) -> Result<BTreeMap<String, Vec<String>>>;
     /// How to delete a stored pod (does not propagate).
-    fn delete_pod(&self, name: &str, version: &str) -> OrcaResult<()>;
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there is an issue deleting a pod from the store using `name` and
+    /// `version`.
+    fn delete_pod(&self, name: &str, version: &str) -> Result<()>;
 }
 /// Store implementation on a local filesystem.
 pub mod filestore;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,11 +1,16 @@
 use crate::{error::OrcaResult, model::Pod};
 use std::collections::BTreeMap;
 
+/// Standard behavior of any store backend supported.
 pub trait Store {
+    /// How a pod is stored.
     fn save_pod(&self, pod: &Pod) -> OrcaResult<()>;
+    /// How to load a stored pod into a model instance.
     fn load_pod(&self, name: &str, version: &str) -> OrcaResult<Pod>;
+    /// How to query stored pods.
     fn list_pod(&self) -> OrcaResult<BTreeMap<String, Vec<String>>>;
+    /// How to delete a stored pod (does not propagate).
     fn delete_pod(&self, name: &str, version: &str) -> OrcaResult<()>;
 }
-
+/// Store implementation on a local filesystem.
 pub mod filestore;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,11 +1,11 @@
-use crate::model::Pod;
-use std::{collections::BTreeMap, error::Error};
+use crate::{error::OrcaResult, model::Pod};
+use std::collections::BTreeMap;
 
 pub trait Store {
-    fn save_pod(&self, pod: &Pod) -> Result<(), Box<dyn Error>>;
-    fn load_pod(&self, name: &str, version: &str) -> Result<Pod, Box<dyn Error>>;
-    fn list_pod(&self) -> Result<BTreeMap<String, Vec<String>>, Box<dyn Error>>;
-    fn delete_pod(&self, name: &str, version: &str) -> Result<(), Box<dyn Error>>;
+    fn save_pod(&self, pod: &Pod) -> OrcaResult<()>;
+    fn load_pod(&self, name: &str, version: &str) -> OrcaResult<Pod>;
+    fn list_pod(&self) -> OrcaResult<BTreeMap<String, Vec<String>>>;
+    fn delete_pod(&self, name: &str, version: &str) -> OrcaResult<()>;
 }
 
 pub mod filestore;

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@ use std::any::type_name;
 
 #[expect(
     clippy::unwrap_used,
-    reason = "`None` impossible since `type_name` always returns `&str`."
+    reason = "`last()` cannot return `None` since `type_name` always returns `&str`."
 )]
 pub fn get_type_name<T>() -> String {
     type_name::<T>()

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -1,12 +1,17 @@
+#![expect(
+    clippy::missing_errors_doc,
+    reason = "Integration tests won't be included in documentation."
+)]
+
 use orcapod::{
-    error::OrcaResult,
+    error::Result,
     model::{Annotation, Pod, StreamInfo},
     store::{filestore::LocalFileStore, Store},
 };
 use std::{collections::BTreeMap, fs, ops::Deref, path::PathBuf};
 use tempfile::tempdir;
 
-pub fn pod_style() -> OrcaResult<Pod> {
+pub fn pod_style() -> Result<Pod> {
     Pod::new(
         Annotation {
             name: "style-transfer".to_owned(),
@@ -51,7 +56,7 @@ pub struct TestLocalStore {
     store: LocalFileStore,
 }
 
-pub fn store_test(store_directory: Option<&str>) -> OrcaResult<TestLocalStore> {
+pub fn store_test(store_directory: Option<&str>) -> Result<TestLocalStore> {
     impl Deref for TestLocalStore {
         type Target = LocalFileStore;
         fn deref(&self) -> &Self::Target {
@@ -79,7 +84,7 @@ pub struct TestLocallyStoredPod<'base> {
     pod: Pod,
 }
 
-pub fn add_pod_storage(pod: Pod, store: &TestLocalStore) -> OrcaResult<TestLocallyStoredPod> {
+pub fn add_pod_storage(pod: Pod, store: &TestLocalStore) -> Result<TestLocallyStoredPod> {
     impl<'base> Deref for TestLocallyStoredPod<'base> {
         type Target = Pod;
         fn deref(&self) -> &Self::Target {

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -1,11 +1,12 @@
 use orcapod::{
+    error::OrcaResult,
     model::{Annotation, Pod, StreamInfo},
     store::{filestore::LocalFileStore, Store},
 };
-use std::{collections::BTreeMap, error::Error, fs, ops::Deref, path::PathBuf};
+use std::{collections::BTreeMap, fs, ops::Deref, path::PathBuf};
 use tempfile::tempdir;
 
-pub fn pod_style() -> Result<Pod, Box<dyn Error>> {
+pub fn pod_style() -> OrcaResult<Pod> {
     Pod::new(
         Annotation {
             name: "style-transfer".to_owned(),
@@ -50,11 +51,7 @@ pub struct TestLocalStore {
     store: LocalFileStore,
 }
 
-#[expect(
-    clippy::expect_used,
-    reason = "Required since can't modify drop signature."
-)]
-pub fn store_test(store_directory: Option<&str>) -> Result<TestLocalStore, Box<dyn Error>> {
+pub fn store_test(store_directory: Option<&str>) -> OrcaResult<TestLocalStore> {
     impl Deref for TestLocalStore {
         type Target = LocalFileStore;
         fn deref(&self) -> &Self::Target {
@@ -62,6 +59,10 @@ pub fn store_test(store_directory: Option<&str>) -> Result<TestLocalStore, Box<d
         }
     }
     impl Drop for TestLocalStore {
+        #[expect(
+            clippy::expect_used,
+            reason = "Required since can't modify drop signature."
+        )]
         fn drop(&mut self) {
             fs::remove_dir_all(self.store.directory.as_path()).expect("Failed to teardown store.");
         }
@@ -78,14 +79,7 @@ pub struct TestLocallyStoredPod<'base> {
     pod: Pod,
 }
 
-#[expect(
-    clippy::expect_used,
-    reason = "Required since can't modify drop signature."
-)]
-pub fn add_pod_storage(
-    pod: Pod,
-    store: &TestLocalStore,
-) -> Result<TestLocallyStoredPod, Box<dyn Error>> {
+pub fn add_pod_storage(pod: Pod, store: &TestLocalStore) -> OrcaResult<TestLocallyStoredPod> {
     impl<'base> Deref for TestLocallyStoredPod<'base> {
         type Target = Pod;
         fn deref(&self) -> &Self::Target {
@@ -93,6 +87,10 @@ pub fn add_pod_storage(
         }
     }
     impl<'base> Drop for TestLocallyStoredPod<'base> {
+        #[expect(
+            clippy::expect_used,
+            reason = "Required since can't modify drop signature."
+        )]
         fn drop(&mut self) {
             self.store
                 .delete_pod(&self.pod.annotation.name, &self.pod.annotation.version)

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -4,12 +4,12 @@ pub mod fixture;
 use fixture::pod_style;
 use indoc::indoc;
 use orcapod::{
-    error::OrcaResult,
+    error::Result,
     model::{to_yaml, Pod},
 };
 
 #[test]
-fn verify_hash() -> OrcaResult<()> {
+fn verify_hash() -> Result<()> {
     assert_eq!(
         pod_style()?.hash,
         "13D69656D396C272588DD875B2802FAEE1A56BD985E3C43C7DB276A373BC9DDB"
@@ -18,7 +18,7 @@ fn verify_hash() -> OrcaResult<()> {
 }
 
 #[test]
-fn verify_pod_to_yaml() -> OrcaResult<()> {
+fn verify_pod_to_yaml() -> Result<()> {
     assert_eq!(
         to_yaml::<Pod>(&pod_style()?)?,
         indoc! {"

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,13 +1,15 @@
 #![expect(clippy::panic_in_result_fn, reason = "Panics OK in tests.")]
 
-use std::error::Error;
 pub mod fixture;
 use fixture::pod_style;
 use indoc::indoc;
-use orcapod::model::{to_yaml, Pod};
+use orcapod::{
+    error::OrcaResult,
+    model::{to_yaml, Pod},
+};
 
 #[test]
-fn verify_hash() -> Result<(), Box<dyn Error>> {
+fn verify_hash() -> OrcaResult<()> {
     assert_eq!(
         pod_style()?.hash,
         "13D69656D396C272588DD875B2802FAEE1A56BD985E3C43C7DB276A373BC9DDB"
@@ -16,7 +18,7 @@ fn verify_hash() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn verify_pod_to_yaml() -> Result<(), Box<dyn Error>> {
+fn verify_pod_to_yaml() -> OrcaResult<()> {
     assert_eq!(
         to_yaml::<Pod>(&pod_style()?)?,
         indoc! {"

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -12,9 +12,9 @@ use tempfile::tempdir;
 fn is_dir_two_levels_up_empty(file: &Path) -> Result<bool> {
     Ok(file
         .parent()
-        .ok_or_else(|| OrcaError::FileHasNoParent(file.to_path_buf()))?
+        .ok_or_else(|| OrcaError::file_has_no_parent(file.to_path_buf()))?
         .parent()
-        .ok_or_else(|| OrcaError::FileHasNoParent(file.to_path_buf()))?
+        .ok_or_else(|| OrcaError::file_has_no_parent(file.to_path_buf()))?
         .read_dir()?
         .next()
         .is_none())

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -3,13 +3,13 @@
 pub mod fixture;
 use fixture::{add_pod_storage, pod_style, store_test};
 use orcapod::{
-    error::{OrcaError, OrcaResult},
+    error::{OrcaError, Result},
     model::{to_yaml, Pod},
 };
 use std::{fs, path::Path};
 use tempfile::tempdir;
 
-fn is_dir_two_levels_up_empty(file: &Path) -> OrcaResult<bool> {
+fn is_dir_two_levels_up_empty(file: &Path) -> Result<bool> {
     Ok(file
         .parent()
         .ok_or_else(|| OrcaError::FileHasNoParent(file.to_path_buf()))?
@@ -21,7 +21,7 @@ fn is_dir_two_levels_up_empty(file: &Path) -> OrcaResult<bool> {
 }
 
 #[test]
-fn verify_pod_save_and_delete() -> OrcaResult<()> {
+fn verify_pod_save_and_delete() -> Result<()> {
     let store_directory = String::from(tempdir()?.path().to_string_lossy());
     {
         let pod_style = pod_style()?;

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -3,29 +3,25 @@
 pub mod fixture;
 use fixture::{add_pod_storage, pod_style, store_test};
 use orcapod::{
-    error::FileHasNoParent,
+    error::{OrcaError, OrcaResult},
     model::{to_yaml, Pod},
 };
-use std::{error::Error, fs, path::Path};
+use std::{fs, path::Path};
 use tempfile::tempdir;
 
-fn is_dir_two_levels_up_empty(file: &Path) -> Result<bool, Box<dyn Error>> {
+fn is_dir_two_levels_up_empty(file: &Path) -> OrcaResult<bool> {
     Ok(file
         .parent()
-        .ok_or_else(|| FileHasNoParent {
-            path: file.to_path_buf(),
-        })?
+        .ok_or_else(|| OrcaError::FileHasNoParent(file.to_path_buf()))?
         .parent()
-        .ok_or_else(|| FileHasNoParent {
-            path: file.to_path_buf(),
-        })?
+        .ok_or_else(|| OrcaError::FileHasNoParent(file.to_path_buf()))?
         .read_dir()?
         .next()
         .is_none())
 }
 
 #[test]
-fn verify_pod_save_and_delete() -> Result<(), Box<dyn Error>> {
+fn verify_pod_save_and_delete() -> OrcaResult<()> {
     let store_directory = String::from(tempdir()?.path().to_string_lossy());
     {
         let pod_style = pod_style()?;


### PR DESCRIPTION
- [x] ~Convert error handling to enumeration approach~ Convert error handling to masked enumeration approach
- [x] Apply similar message highlighting as before
- [x] Add API docs
- [x] Make return type for `parse_annotation_path` more readable
- [x] In `save_file`, skip creating directory path as opposed to raising error if no parent
- [x] Improve clippy reason doc in `get_type_name`
- [x] Reduce scope of `expect_used` clippy exception
- [x] Remove temporary clippy exceptions for docs
- [x] Add notes about generating docs HTML site and coverage report HTML site

Fix #25 
Fix #20 