### PR TITLE
Generics and annotation improvements, Part 2

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,4 @@
-excessive-nesting-threshold = 5
+excessive-nesting-threshold = 3
 too-many-arguments-threshold = 10
 allowed-prefixes = ["..", "GPU", "Orca"]
 min-ident-chars-threshold = 2

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,8 @@
 				"vadimcn.vscode-lldb", // Rust CodeLLDB debugger
 				"ms-vscode.hexeditor", // Binary preview in HEX
 				"tamasfe.even-better-toml", // *.toml language support
-				"eamodio.gitlens" // Git explorer in VSCode
+				"eamodio.gitlens", // Git explorer in VSCode
+				"streetsidesoftware.code-spell-checker" // Catch spelling errors in docs
 			]
 		}
 	}

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -32,7 +32,8 @@
 				"vadimcn.vscode-lldb", // Rust CodeLLDB debugger
 				"ms-vscode.hexeditor", // Binary preview in HEX
 				"tamasfe.even-better-toml", // *.toml language support
-				"eamodio.gitlens" // Git explorer in VSCode
+				"eamodio.gitlens", // Git explorer in VSCode
+				"streetsidesoftware.code-spell-checker" // Catch spelling errors in docs
 			]
 		}
 	}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
             "args": [
                 "--exact",
                 "--nocapture",
-                "verify_hash"
+                "hash"
             ],
             "cwd": "${workspaceFolder}",
         },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ serde_yaml = "0.9.34"
 sha2 = "0.10.8"
 glob = "0.3.1"
 regex = "1.11.0"
+heck = "0.5.0"
 colored = "2.1.0"
-anyhow = "1.0.91"
 
 [dev-dependencies]
 tempfile = "3.13.0"
@@ -51,14 +51,12 @@ restriction = "deny"
 nursery = "deny"
 cargo = "deny"
 
-
 arithmetic_side_effects = { level = "allow", priority = 127 }          # allow arithmatic for convenience though it could overflow
 as_conversions = { level = "allow", priority = 127 }                   # allow casting
 assertions_on_result_states = { level = "allow", priority = 127 }      # allow checking is_ok/is_err
 big_endian_bytes = { level = "allow", priority = 127 }                 # allow to_be_bytes / from_be_bytes
 blanket_clippy_restriction_lints = { level = "allow", priority = 127 } # allow setting all restrictions so we can omit specific ones
 default_numeric_fallback = { level = "allow", priority = 127 }         # allow type inferred by numeric literal
-decimal_literal_representation = { level = "allow", priority = 127 }   # It wants to have bytes in hexadecimal format, which is not a common use case
 disallowed_script_idents = { level = "allow", priority = 127 }         # skip since we use only ascii
 else_if_without_else = { level = "allow", priority = 127 }             # missing else ok
 exhaustive_enums = { level = "allow", priority = 127 }                 # revist once lib is ready to be used externally
@@ -75,7 +73,6 @@ missing_asserts_for_indexing = { level = "allow", priority = 127 }     # missing
 missing_docs_in_private_items = { level = "allow", priority = 127 }    # missing docs on private ok
 missing_inline_in_public_items = { level = "allow", priority = 127 }   # let rust compiler determine best inline logic
 missing_trait_methods = { level = "allow", priority = 127 }            # allow in favor of rustc `implement the missing item`
-multiple_crate_versions = { level = "allow", priority = 127 }          # This is to deal with colorized using an older dependency vs fs4
 must_use_candidate = { level = "allow", priority = 127 }               # omitting #[must_use] ok
 mod_module_files = { level = "allow", priority = 127 }                 # mod directories ok
 non_ascii_literal = { level = "allow", priority = 127 }                # non-ascii char in string literal ok
@@ -98,8 +95,7 @@ string_add = { level = "allow", priority = 127 }                       # simple 
 string_lit_chars_any = { level = "allow", priority = 127 }             # favor readability until a perf case comes up
 todo = { level = "warn", priority = 127 }                              # warn todos
 use_debug = { level = "warn", priority = 127 }                         # debug print
+
 # temporary
-missing_panics_doc = { level = "allow", priority = 127 }        # remove because of constant panic in test due to unwrap
-missing_errors_doc = { level = "allow", priority = 127 }        # remove once we have docs
 single_call_fn = { level = "allow", priority = 127 }            # remove once other models are in
 tests_outside_test_module = { level = "allow", priority = 127 } # for now due to false-positive for integration tests: https://github.com/rust-lang/rust-clippy/pull/13038

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,14 @@
+{
+    "ignoreWords": [
+        "relpath",
+        "filestore",
+        "cpus",
+        "orcapod",
+        "tempfile",
+        "tempdir",
+        "millicores",
+        "zenmldocker",
+        "zenml",
+        "indoc"
+    ]
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use anyhow;
 use colored::Colorize;
 use glob;
 use regex;
@@ -9,24 +8,28 @@ use std::{
     fmt::{Display, Formatter},
     io,
     path::PathBuf,
+    result,
 };
 /// Shorthand for a Result that returns an `OrcaError`.
-pub type Result<T> = anyhow::Result<T, OrcaError>;
-// pub type Result<T> = result::Result<T, OrcaError>;
+pub type Result<T> = result::Result<T, OrcaError>;
 
 /// Possible errors you may encounter.
 #[derive(Debug)]
 pub(crate) enum Kind {
     /// Returned if a file is not expected to exist.
     FileExists(PathBuf),
-    /// Returned if a file is expected to have a parent.
-    FileHasNoParent(PathBuf),
     /// Returned if an annotation was expected to exist.
     NoAnnotationFound(String, String, String),
+    /// Returned if a model save was attempted without an annotation set.
+    MissingAnnotationOnSave,
+    /// Returned if an annotation delete was attempted on a model's last annotation.
+    DeletingLastAnnotation(String, String, String),
+    /// Returned if a regular expression was expected to match.
+    NoRegexMatch,
     /// Wrapper around `glob::GlobError`
     GlobError(glob::GlobError),
     /// Wrapper around `glob::PatternError`
-    GlobPaternError(glob::PatternError),
+    GlobPatternError(glob::PatternError),
     /// Wrapper around `regex::Error`
     RegexError(regex::Error),
     /// Wrapper around `serde_yaml::Error`
@@ -49,18 +52,23 @@ impl Display for OrcaError {
                     path.to_string_lossy().bright_cyan()
                 )
             }
-            Kind::FileHasNoParent(path) => {
-                write!(
-                    f,
-                    "File `{}` has no parent.",
-                    path.to_string_lossy().bright_red()
-                )
-            }
             Kind::NoAnnotationFound(class, name, version) => {
                 write!(f, "No annotation found for `{name}:{version}` {class}.")
             }
+            Kind::MissingAnnotationOnSave => {
+                write!(f, "No annotation found when attempting to store.")
+            }
+            Kind::DeletingLastAnnotation(class, name, version) => {
+                write!(
+                    f,
+                    "Attempted to delete the last annotation for `{name}:{version}` {class}."
+                )
+            }
+            Kind::NoRegexMatch => {
+                write!(f, "No match for regex.")
+            }
             Kind::GlobError(error) => write!(f, "{error}"),
-            Kind::GlobPaternError(error) => write!(f, "{error}"),
+            Kind::GlobPatternError(error) => write!(f, "{error}"),
             Kind::SerdeYamlError(error) => write!(f, "{error}"),
             Kind::RegexError(error) => write!(f, "{error}"),
             Kind::IoError(error) => write!(f, "{error}"),
@@ -74,7 +82,7 @@ impl From<glob::GlobError> for OrcaError {
 }
 impl From<glob::PatternError> for OrcaError {
     fn from(error: glob::PatternError) -> Self {
-        Self(Kind::GlobPaternError(error))
+        Self(Kind::GlobPatternError(error))
     }
 }
 impl From<serde_yaml::Error> for OrcaError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,12 @@ pub(crate) enum Kind {
 #[derive(Debug)]
 pub struct OrcaError(Kind);
 impl Error for OrcaError {}
+impl OrcaError {
+    /// Returns `true` if the error was caused by an attempt to delete a model's last annotation.
+    pub const fn is_deleting_last_annotation(&self) -> bool {
+        matches!(self.0, Kind::DeletingLastAnnotation(_, _, _))
+    }
+}
 impl Display for OrcaError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match &self.0 {

--- a/src/model.rs
+++ b/src/model.rs
@@ -29,31 +29,25 @@ pub fn to_yaml<T: Serialize>(instance: &T) -> Result<String> {
 /// Will return `Err` if there is an issue converting YAML files for spec+annotation into a model
 /// instance.
 pub fn from_yaml<T: DeserializeOwned>(
-    spec_yaml: &str,
     hash: &str,
+    spec_yaml: &str,
     annotation_yaml: Option<&str>,
 ) -> Result<T> {
-    let mut spec_mapping: BTreeMap<String, Value> = serde_yaml::from_str(spec_yaml)?;
-
-    // Insert annotation if there is something
-    if let Some(yaml) = annotation_yaml {
-        let annotation_map: Mapping = serde_yaml::from_str(yaml)?;
-        spec_mapping.insert("annotation".into(), Value::from(annotation_map));
+    let mut spec: BTreeMap<String, Value> = serde_yaml::from_str(spec_yaml)?;
+    spec.insert("hash".to_owned(), Value::from(hash));
+    if let Some(resolved_annotation_yaml) = annotation_yaml {
+        let annotation: Mapping = serde_yaml::from_str(resolved_annotation_yaml)?;
+        spec.insert("annotation".to_owned(), Value::from(annotation));
     }
-    spec_mapping.insert("hash".to_owned(), Value::from(hash));
 
-    Ok(serde_yaml::from_str(&serde_yaml::to_string(
-        &spec_mapping,
-    )?)?)
+    Ok(serde_yaml::from_str(&serde_yaml::to_string(&spec)?)?)
 }
 
 // --- core model structs ---
 
 /// A reusable, containerized computational unit.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Pod {
-    /// Metadata that doesn't affect reproducibility.
-    pub annotation: Option<Annotation>,
     /// Unique id based on reproducibility.
     pub hash: String,
     source_commit_url: String,
@@ -64,6 +58,8 @@ pub struct Pod {
     output_stream_map: BTreeMap<String, StreamInfo>,
     recommended_cpus: f32,
     recommended_memory: u64,
+    /// Metadata that doesn't affect reproducibility.
+    pub annotation: Option<Annotation>,
     required_gpu: Option<GPURequirement>,
 }
 
@@ -74,7 +70,6 @@ impl Pod {
     ///
     /// Will return `Err` if there is an issue initializing a `Pod` instance.
     pub fn new(
-        annotation: Option<Annotation>,
         source_commit_url: String,
         image: String,
         command: String,
@@ -83,10 +78,10 @@ impl Pod {
         output_stream_map: BTreeMap<String, StreamInfo>,
         recommended_cpus: f32,
         recommended_memory: u64,
+        annotation: Option<Annotation>,
         required_gpu: Option<GPURequirement>,
     ) -> Result<Self> {
         let pod_no_hash = Self {
-            annotation,
             hash: String::new(),
             source_commit_url,
             image,
@@ -96,6 +91,7 @@ impl Pod {
             output_stream_map,
             recommended_cpus,
             recommended_memory,
+            annotation,
             required_gpu,
         };
         Ok(Self {
@@ -108,7 +104,7 @@ impl Pod {
 // --- util types ---
 
 /// Standard metadata structure for all model instances.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Annotation {
     /// A unique name.
     pub name: String,
@@ -135,7 +131,7 @@ pub enum GPUModel {
     /// AMD-manufactured card where `String` is the specific model e.g. ???
     AMD(String),
 }
-/// Streams are named and represent an abstration for the file(s) that represent some particular
+/// Streams are named and represent an abstraction for the file(s) that represent some particular
 /// data.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct StreamInfo {

--- a/src/model.rs
+++ b/src/model.rs
@@ -48,6 +48,8 @@ pub fn from_yaml<T: DeserializeOwned>(
 /// A reusable, containerized computational unit.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Pod {
+    /// Metadata that doesn't affect reproducibility.
+    pub annotation: Option<Annotation>,
     /// Unique id based on reproducibility.
     pub hash: String,
     source_commit_url: String,
@@ -58,8 +60,6 @@ pub struct Pod {
     output_stream_map: BTreeMap<String, StreamInfo>,
     recommended_cpus: f32,
     recommended_memory: u64,
-    /// Metadata that doesn't affect reproducibility.
-    pub annotation: Option<Annotation>,
     required_gpu: Option<GPURequirement>,
 }
 
@@ -70,6 +70,7 @@ impl Pod {
     ///
     /// Will return `Err` if there is an issue initializing a `Pod` instance.
     pub fn new(
+        annotation: Option<Annotation>,
         source_commit_url: String,
         image: String,
         command: String,
@@ -78,10 +79,10 @@ impl Pod {
         output_stream_map: BTreeMap<String, StreamInfo>,
         recommended_cpus: f32,
         recommended_memory: u64,
-        annotation: Option<Annotation>,
         required_gpu: Option<GPURequirement>,
     ) -> Result<Self> {
         let pod_no_hash = Self {
+            annotation,
             hash: String::new(),
             source_commit_url,
             image,
@@ -91,7 +92,6 @@ impl Pod {
             output_stream_map,
             recommended_cpus,
             recommended_memory,
-            annotation,
             required_gpu,
         };
         Ok(Self {

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -8,7 +8,6 @@ use colored::Colorize;
 use regex::Regex;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
-    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -34,7 +33,7 @@ impl Store for LocalFileStore {
         self.load_model(model_id)
     }
 
-    fn list_pod(&self) -> Result<BTreeMap<String, Vec<String>>> {
+    fn list_pod(&self) -> Result<Vec<ModelInfo>> {
         self.list_model::<Pod>()
     }
 
@@ -204,24 +203,9 @@ impl LocalFileStore {
         }
     }
 
-    fn list_model<T>(&self) -> Result<BTreeMap<String, Vec<String>>> {
-        let (names, (hashes, versions)) = Self::find_annotation(
-            &self.make_path::<T>("*", &Self::make_annotation_relpath("*", "*")),
-        )?
-        .map(|model_info| {
-            let resolved_model_info = model_info?;
-            Ok((
-                resolved_model_info.name,
-                (resolved_model_info.hash, resolved_model_info.version),
-            ))
-        })
-        .collect::<Result<(Vec<_>, (Vec<_>, Vec<_>))>>()?;
-
-        Ok(BTreeMap::from([
-            (String::from("name"), names),
-            (String::from("hash"), hashes),
-            (String::from("version"), versions),
-        ]))
+    fn list_model<T>(&self) -> Result<Vec<ModelInfo>> {
+        Self::find_annotation(&self.make_path::<T>("*", &Self::make_annotation_relpath("*", "*")))?
+            .collect()
     }
 
     fn delete_model<T>(&self, model_id: &ModelID) -> Result<()> {

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::{Kind, OrcaError, Result},
     model::{from_yaml, to_yaml, Annotation, Pod},
+    store::{ModelID, ModelInfo, Store},
     util::get_type_name,
 };
 use colored::Colorize;
@@ -11,36 +12,29 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
-
-use super::{ModelID, ModelInfo, Store};
-
-const SPEC_FILE_NAME: &str = "spec.yaml";
-
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
-struct NameVerTreeKey {
-    name: String,
-    version: String,
-}
-
-/// Local storage system for orca items implmenting store
+/// Support for a storage backend on a local filesystem directory.
 #[derive(Debug)]
 pub struct LocalFileStore {
+    /// A local path to a directory where store will be located.
     directory: PathBuf,
 }
 
 impl Store for LocalFileStore {
     fn save_pod(&self, pod: &Pod) -> Result<()> {
-        self.save_model(pod, &pod.hash, pod.annotation.as_ref())
+        self.save_model(
+            pod,
+            &pod.hash,
+            pod.annotation
+                .as_ref()
+                .ok_or_else(|| OrcaError::from(Kind::MissingAnnotationOnSave))?,
+        )
     }
 
     fn load_pod(&self, model_id: &ModelID) -> Result<Pod> {
-        self.load_model::<Pod>(model_id)
+        self.load_model(model_id)
     }
 
-    /// Return Btree where key is column name and value is a vec of values
-    /// Are we okay with returning a bunch of strings? For now it works but later on like adding version
-    /// this will break...
-    fn list_pod(&self) -> Result<Vec<ModelInfo>> {
+    fn list_pod(&self) -> Result<BTreeMap<String, Vec<String>>> {
         self.list_model::<Pod>()
     }
 
@@ -49,206 +43,196 @@ impl Store for LocalFileStore {
     }
 
     fn delete_annotation<T>(&self, name: &str, version: &str) -> Result<()> {
-        // Search the name ver index for the hash
-        let hash = self.get_hash_from_name_ver_tree::<T>(name, version)?;
+        let hash = self.lookup_hash::<T>(name, version)?;
+        let (count, _) = Self::parse_annotation_path(
+            &self.make_path::<T>(&hash, Self::make_annotation_relpath("*", "*")),
+        )?
+        .size_hint();
+        if count == 1 {
+            return Err(OrcaError::from(Kind::DeletingLastAnnotation(
+                get_type_name::<T>(),
+                name.to_owned(),
+                version.to_owned(),
+            )));
+        }
+        let annotation_file =
+            self.make_path::<T>(&hash, &Self::make_annotation_relpath(name, version));
+        fs::remove_file(&annotation_file)?;
 
-        fs::remove_file(self.make_annotation_path::<T>(&hash, name, version))?;
         Ok(())
     }
 }
 
 impl LocalFileStore {
-    /// New function that takes the directory as where to save the files
+    /// Construct a local file store instance in a specific directory.
     pub fn new(directory: impl AsRef<Path>) -> Self {
         Self {
             directory: directory.as_ref().into(),
         }
     }
-
-    /// Getter function for directory
+    /// Get the directory where store is located.
     pub fn get_directory(&self) -> &Path {
         &self.directory
     }
-
-    fn make_dir_path<T>(&self, hash: &str) -> PathBuf {
+    /// Relative path where model specification is stored within the model directory.
+    pub const SPEC_RELPATH: &str = "spec.yaml";
+    /// Relative path where model annotation is stored within the model directory.
+    pub fn make_annotation_relpath(name: &str, version: &str) -> PathBuf {
+        PathBuf::from(format!("annotation/{name}-{version}.yaml"))
+    }
+    /// Build the storage path with the model directory (`hash`) and a file's relative path.
+    pub fn make_path<T>(&self, hash: &str, relpath: impl AsRef<Path>) -> PathBuf {
         PathBuf::from(format!(
             "{}/{}/{}",
             self.directory.to_string_lossy(),
             get_type_name::<T>(),
-            hash,
+            hash
         ))
+        .join(relpath)
     }
 
-    /// Helper function for making path to a given item type T
-    pub fn make_path<T>(&self, hash: &str, file_name: &str) -> PathBuf {
-        self.make_dir_path::<T>(hash).join(file_name)
-    }
-
-    /// Helper function to create the path to the annotations files
-    pub fn make_annotation_path<T>(&self, hash: &str, name: &str, version: &str) -> PathBuf {
-        self.make_dir_path::<T>(hash)
-            .join("annotations")
-            .join(format!("{name}-{version}.yaml"))
-    }
-
-    // Generic function for save load list delete
-    /// Generic func to save all sorts of item
-    ///
-    /// Example usage inside `LocalFileStore`
-    /// ``` markdown
-    /// let pod = Pod::new(); // For example doesn't actually work
-    /// self.save_item(pod, &pod.annotation, &pod.hash).unwrap()
-    /// ```
-    fn save_model<T: Serialize>(
-        &self,
-        item: &T,
-        hash: &str,
-        annotation: Option<&Annotation>,
-    ) -> Result<()> {
-        // Save the item first
-        Self::save_file(
-            self.make_path::<T>(hash, SPEC_FILE_NAME),
-            &to_yaml::<T>(item)?,
-            false,
+    fn parse_annotation_path(path: &Path) -> Result<impl Iterator<Item = Result<ModelInfo>>> {
+        let re = Regex::new(
+            r"(?x)
+            ^.*
+            \/(?<class>[a-z_]+)
+                \/(?<hash>[0-9a-f]+)
+                    \/annotation
+                        \/
+                        (?<name>[0-9a-zA-Z\-]+)
+                        -
+                        (?<version>[0-9]+\.[0-9]+\.[0-9]+)
+                        \.yaml
+            $",
         )?;
-
-        // Save the annotation file and throw and error if exist
-        if let Some(value) = annotation {
-            // Annotation exist, thus save it
-            Self::save_file(
-                self.make_annotation_path::<T>(hash, &value.name, &value.version),
-                &serde_yaml::to_string(value)?,
-                true,
-            )?;
-        }
-
-        Ok(())
-    }
-
-    fn list_model<T>(&self) -> Result<Vec<ModelInfo>> {
-        let name_ver_tree = self.build_name_ver_tree::<T>()?;
-        let mut models = Vec::with_capacity(name_ver_tree.len());
-        for (key, hash) in name_ver_tree {
-            models.push(ModelInfo {
-                name: key.name,
-                version: key.version,
-                hash,
-            });
-        }
-
-        Ok(models)
-    }
-
-    /// Generic function for loading spec.yaml into memory
-    fn load_model<T: DeserializeOwned>(&self, model_id: &ModelID) -> Result<T> {
-        match model_id {
-            ModelID::NameVer(name, version) => {
-                // Search the name-ver index
-                let hash = self.get_hash_from_name_ver_tree::<T>(name, version)?;
-
-                // Get the spec and annotation yaml
-                let spec_yaml = fs::read_to_string(self.make_path::<T>(&hash, SPEC_FILE_NAME))?;
-
-                let annotation_yaml =
-                    fs::read_to_string(self.make_annotation_path::<T>(&hash, name, version))?;
-
-                from_yaml::<T>(&spec_yaml, &hash, Some(&annotation_yaml))
-            }
-            ModelID::Hash(hash) => {
-                // Get the spec and annotation yaml
-                let spec_yaml = fs::read_to_string(self.make_path::<T>(hash, SPEC_FILE_NAME))?;
-                from_yaml::<T>(&spec_yaml, hash, None)
-            }
-        }
-    }
-
-    fn delete_model<T>(&self, model_id: &ModelID) -> Result<()> {
-        let hash = match model_id {
-            ModelID::NameVer(name, version) => {
-                // Search the name-ver index
-                self.get_hash_from_name_ver_tree::<T>(name, version)?
-            }
-            ModelID::Hash(hash) => hash.to_owned(),
-        };
-
-        fs::remove_dir_all(self.make_dir_path::<T>(&hash))?;
-        Ok(())
-    }
-
-    fn build_name_ver_tree<T>(&self) -> Result<BTreeMap<NameVerTreeKey, String>> {
-        // Construct the cache with glob and regex
-        let type_name = get_type_name::<T>();
-        let re = Regex::new(&format!(
-            r"^.*\/{type_name}\/(?<hash>[a-z0-9]+)\/annotations\/(?<name>[A-z0-9\- ]+)-(?<ver>[0-9]+.[0-9]+.[0-9]+).yaml$"
-        ))?;
-
-        // Create tree where name_ver is key and value is hash
-        let mut name_ver_tree = BTreeMap::new();
-
-        let search_pattern = self.make_dir_path::<T>("*").join("annotations/*");
-
-        for path in glob::glob(&search_pattern.to_string_lossy())? {
-            let path_str: String = path?.to_string_lossy().to_string();
-
-            let Some(cap) = re.captures(&path_str) else {
-                continue; // Add the no regex nomatch back
-            };
-
-            name_ver_tree.insert(
-                NameVerTreeKey {
-                    name: cap["name"].to_string(),
-                    version: cap["ver"].to_string(),
-                },
-                cap["hash"].into(),
-            );
-        }
-
-        Ok(name_ver_tree)
-    }
-
-    fn get_hash_from_name_ver_tree<T>(&self, name: &str, version: &str) -> Result<String> {
-        Ok(self
-            .build_name_ver_tree::<T>()?
-            .get(&NameVerTreeKey {
-                name: name.to_owned(),
-                version: version.to_owned(),
+        let paths = glob::glob(&path.to_string_lossy())?.map(move |filepath| {
+            let filepath_string = String::from(filepath?.to_string_lossy());
+            let group = re
+                .captures(&filepath_string)
+                .ok_or_else(|| OrcaError::from(Kind::NoRegexMatch))?;
+            Ok(ModelInfo {
+                name: group["name"].to_string(),
+                version: group["version"].to_string(),
+                hash: group["hash"].to_string(),
             })
-            .ok_or_else(|| {
-                OrcaError::from(Kind::NoAnnotationFound(
-                    get_type_name::<T>(),
-                    name.into(),
-                    version.into(),
-                ))
-            })?
-            .to_owned())
+        });
+        Ok(paths)
     }
 
-    // Help save file function
+    fn lookup_hash<T>(&self, name: &str, version: &str) -> Result<String> {
+        let model_info = Self::parse_annotation_path(
+            &self.make_path::<T>("*", &Self::make_annotation_relpath(name, version)),
+        )?
+        .next()
+        .ok_or_else(|| {
+            OrcaError::from(Kind::NoAnnotationFound(
+                get_type_name::<T>(),
+                name.to_owned(),
+                version.to_owned(),
+            ))
+        })??;
+        Ok(model_info.hash)
+    }
+
     fn save_file(
-        path: impl AsRef<Path>,
+        file: impl AsRef<Path>,
         content: impl AsRef<[u8]>,
         fail_if_exists: bool,
     ) -> Result<()> {
-        fs::create_dir_all(
-            path.as_ref().parent().ok_or_else(|| {
-                OrcaError::from(Kind::FileHasNoParent(path.as_ref().to_path_buf()))
-            })?,
-        )?;
-        if path.as_ref().exists() {
-            if fail_if_exists {
-                return Err(OrcaError::from(Kind::FileExists(
-                    path.as_ref().to_path_buf(),
-                )));
-            }
-
+        if let Some(parent) = file.as_ref().parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let file_exists = file.as_ref().exists();
+        if file_exists && fail_if_exists {
+            return Err(OrcaError::from(Kind::FileExists(
+                file.as_ref().to_path_buf(),
+            )));
+        } else if file_exists {
             println!(
                 "Skip saving `{}` since it is already stored.",
-                path.as_ref().to_string_lossy().bright_cyan(),
+                file.as_ref().to_string_lossy().bright_cyan(),
             );
-            return Ok(());
+        } else {
+            fs::write(file, content)?;
         }
+        Ok(())
+    }
 
-        fs::write(path.as_ref(), content.as_ref())?;
+    fn save_model<T: Serialize>(
+        &self,
+        model: &T,
+        hash: &str,
+        annotation: &Annotation,
+    ) -> Result<()> {
+        // Save the annotation file and throw and error if exist
+        Self::save_file(
+            self.make_path::<T>(
+                hash,
+                &Self::make_annotation_relpath(&annotation.name, &annotation.version),
+            ),
+            &serde_yaml::to_string(&annotation)?,
+            true,
+        )?;
+        // Save the pod and skip if it already exist, for the case of many annotation to a single pod
+        Self::save_file(
+            self.make_path::<T>(hash, Self::SPEC_RELPATH),
+            &to_yaml(model)?,
+            false,
+        )?;
+
+        Ok(())
+    }
+
+    fn load_model<T: DeserializeOwned>(&self, model_id: &ModelID) -> Result<T> {
+        match model_id {
+            ModelID::Hash(hash) => from_yaml(
+                hash,
+                &fs::read_to_string(self.make_path::<T>(hash, Self::SPEC_RELPATH))?,
+                None,
+            ),
+            ModelID::Annotation(name, version) => {
+                let hash = self.lookup_hash::<T>(name, version)?;
+                from_yaml(
+                    &hash,
+                    &fs::read_to_string(self.make_path::<T>(&hash, Self::SPEC_RELPATH))?,
+                    Some(&fs::read_to_string(self.make_path::<T>(
+                        &hash,
+                        &Self::make_annotation_relpath(name, version),
+                    ))?),
+                )
+            }
+        }
+    }
+
+    fn list_model<T>(&self) -> Result<BTreeMap<String, Vec<String>>> {
+        let (names, (hashes, versions)) = Self::parse_annotation_path(
+            &self.make_path::<T>("*", &Self::make_annotation_relpath("*", "*")),
+        )?
+        .map(|model_info| {
+            let resolved_model_info = model_info?;
+            Ok((
+                resolved_model_info.name,
+                (resolved_model_info.hash, resolved_model_info.version),
+            ))
+        })
+        .collect::<Result<(Vec<_>, (Vec<_>, Vec<_>))>>()?;
+
+        Ok(BTreeMap::from([
+            (String::from("name"), names),
+            (String::from("hash"), hashes),
+            (String::from("version"), versions),
+        ]))
+    }
+
+    fn delete_model<T>(&self, model_id: &ModelID) -> Result<()> {
+        // assumes propagate = false
+        let hash = match model_id {
+            ModelID::Hash(hash) => hash,
+            ModelID::Annotation(name, version) => &self.lookup_hash::<T>(name, version)?,
+        };
+        let spec_dir = self.make_path::<T>(hash, "");
+        fs::remove_dir_all(spec_dir)?;
+
         Ok(())
     }
 }

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -44,10 +44,10 @@ impl Store for LocalFileStore {
 
     fn delete_annotation<T>(&self, name: &str, version: &str) -> Result<()> {
         let hash = self.lookup_hash::<T>(name, version)?;
-        let (count, _) = Self::parse_annotation_path(
+        let count = Self::parse_annotation_path(
             &self.make_path::<T>(&hash, Self::make_annotation_relpath("*", "*")),
         )?
-        .size_hint();
+        .count();
         if count == 1 {
             return Err(OrcaError::from(Kind::DeletingLastAnnotation(
                 get_type_name::<T>(),

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,21 +1,18 @@
 use crate::{error::Result, model::Pod};
+use std::collections::BTreeMap;
 
-/// Enum for identification to
+/// Options for identifying a model.
 pub enum ModelID {
-    /// Identification via name and version
-    NameVer(String, String),
-    /// Identification by hash
+    /// Identifying by the hash value of a model as a string.
     Hash(String),
+    /// Identifying by the `(name, version)` of an annotation for a model as strings.
+    Annotation(String, String),
 }
 
-/// Struct for list functios
-pub struct ModelInfo {
-    /// Name from annotation of the model struct
-    pub name: String,
-    /// Version from annotation from model struct
-    pub version: String,
-    /// Hash of the model struct
-    pub hash: String,
+pub(crate) struct ModelInfo {
+    name: String,
+    version: String,
+    hash: String,
 }
 
 /// Standard behavior of any store backend supported.
@@ -38,19 +35,20 @@ pub trait Store {
     /// # Errors
     ///
     /// Will return `Err` if there is an issue querying metadata from existing pods in the store.
-    fn list_pod(&self) -> Result<Vec<ModelInfo>>;
-    /// How to delete a stored pod (does not propagate).
+    fn list_pod(&self) -> Result<BTreeMap<String, Vec<String>>>;
+    /// How to explicitly delete a stored pod and all associated annotations (does not propagate).
     ///
     /// # Errors
     ///
     /// Will return `Err` if there is an issue deleting a pod from the store using `name` and
     /// `version`.
     fn delete_pod(&self, model_id: &ModelID) -> Result<()>;
-
-    /// How to delete only annotation, which will leave the item untouched
+    /// How to explicitly delete an annotation.
     ///
     /// # Errors
-    /// Will return `Err` if there is an issue of finding the annotation and deleting it
+    ///
+    /// Will return `Err` if there is an issue deleting an annotation from the store using `name`
+    /// and `version`.
     fn delete_annotation<T>(&self, name: &str, version: &str) -> Result<()>;
 }
 /// Store implementation on a local filesystem.

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,5 +1,4 @@
 use crate::{error::Result, model::Pod};
-use std::collections::BTreeMap;
 
 /// Options for identifying a model.
 pub enum ModelID {
@@ -9,10 +8,15 @@ pub enum ModelID {
     Annotation(String, String),
 }
 
-pub(crate) struct ModelInfo {
-    name: String,
-    version: String,
-    hash: String,
+/// Metadata for a model.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ModelInfo {
+    /// A model's name.
+    pub name: String,
+    /// A model's version.
+    pub version: String,
+    /// A model's hash.
+    pub hash: String,
 }
 
 /// Standard behavior of any store backend supported.
@@ -35,7 +39,7 @@ pub trait Store {
     /// # Errors
     ///
     /// Will return `Err` if there is an issue querying metadata from existing pods in the store.
-    fn list_pod(&self) -> Result<BTreeMap<String, Vec<String>>>;
+    fn list_pod(&self) -> Result<Vec<ModelInfo>>;
     /// How to explicitly delete a stored pod and all associated annotations (does not propagate).
     ///
     /// # Errors

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use heck::ToSnakeCase;
 use sha2::{Digest, Sha256};
 use std::any::type_name;
 
@@ -11,7 +12,7 @@ pub fn get_type_name<T>() -> String {
         .collect::<Vec<&str>>()
         .last()
         .unwrap()
-        .to_lowercase()
+        .to_snake_case()
 }
 
 pub fn hash(buffer: &str) -> String {

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -1,80 +1,19 @@
-use orcapod::error::Result;
-use orcapod::store::ModelInfo;
+#![expect(clippy::expect_used, reason = "Expect OK in tests.")]
+#![expect(
+    clippy::missing_errors_doc,
+    reason = "Integration tests won't be included in documentation."
+)]
+
 use orcapod::{
-    model::{to_yaml, Annotation, Pod, StreamInfo},
+    error::Result,
+    model::{Annotation, Pod, StreamInfo},
     store::{filestore::LocalFileStore, ModelID, Store},
 };
-use std::{
-    collections::BTreeMap,
-    fs,
-    ops::{Deref, DerefMut},
-    path::PathBuf,
-};
+use std::{collections::BTreeMap, fs, ops::Deref, path::PathBuf};
 use tempfile::tempdir;
 
-#[derive(PartialEq, Clone)]
-pub enum Model {
-    Pod(Pod),
-}
-
-pub enum ModelType {
-    Pod,
-}
-
-impl Model {
-    #[expect(clippy::unwrap_used, reason = "test")]
-    pub fn get_name(&self) -> &str {
-        match self {
-            Self::Pod(pod) => &pod.annotation.as_ref().unwrap().name,
-        }
-    }
-
-    pub fn get_hash(&self) -> &str {
-        match self {
-            Self::Pod(pod) => &pod.hash,
-        }
-    }
-
-    #[expect(clippy::unwrap_used, reason = "test")]
-    pub fn get_version(&self) -> &str {
-        match self {
-            Self::Pod(pod) => &pod.annotation.as_ref().unwrap().version,
-        }
-    }
-
-    pub const fn is_annotation_none(&self) -> bool {
-        match self {
-            Self::Pod(pod) => pod.annotation.is_none(),
-        }
-    }
-
-    pub fn to_yaml(&self) -> Result<String> {
-        match self {
-            Self::Pod(pod) => to_yaml(pod),
-        }
-    }
-
-    #[expect(clippy::unwrap_used, reason = "test")]
-    pub fn set_name(&mut self, name: &str) {
-        match self {
-            Self::Pod(pod) => name.clone_into(&mut pod.annotation.as_mut().unwrap().name),
-        }
-    }
-}
-
-pub fn get_test_item(item_type: &ModelType) -> Result<Model> {
-    match item_type {
-        ModelType::Pod => Ok(Model::Pod(get_test_pod()?)),
-    }
-}
-
-pub fn get_test_pod() -> Result<Pod> {
+pub fn pod_style() -> Result<Pod> {
     Pod::new(
-        Some(Annotation {
-            name: "style-transfer".to_owned(),
-            description: "This is an example pod.".to_owned(),
-            version: "0.67.0".to_owned(),
-        }),
         "https://github.com/zenml-io/zenml/tree/0.67.0".to_owned(),
         "zenmldocker/zenml-server:0.67.0".to_owned(),
         "tail -f /dev/null".to_owned(),
@@ -104,6 +43,11 @@ pub fn get_test_pod() -> Result<Pod> {
         )]),
         0.25,                // 250 millicores as frac cores
         (2_u64) * (1 << 30), // 2GiB in bytes
+        Some(Annotation {
+            name: "style-transfer".to_owned(),
+            description: "This is an example pod.".to_owned(),
+            version: "0.67.0".to_owned(),
+        }),
         None,
     )
 }
@@ -113,85 +57,46 @@ pub struct TestLocalStore {
     store: LocalFileStore,
 }
 
-impl Deref for TestLocalStore {
-    type Target = LocalFileStore;
-    fn deref(&self) -> &Self::Target {
-        &self.store
-    }
-}
-
-impl DerefMut for TestLocalStore {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.store
-    }
-}
-
-#[expect(clippy::expect_used, reason = "test")]
-impl Drop for TestLocalStore {
-    fn drop(&mut self) {
-        fs::remove_dir_all(self.store.get_directory()).expect("Failed to teardown store.");
-    }
-}
-
-#[expect(clippy::unwrap_used, reason = "test")]
-impl TestLocalStore {
-    /// # Panics
-    /// Will panic if fail to fetch stuff related to annotation
-    pub fn make_annotation_path(&self, item: &Model) -> PathBuf {
-        match item {
-            Model::Pod(pod) => self.store.make_annotation_path::<Pod>(
-                &pod.hash,
-                &pod.annotation.as_ref().unwrap().name,
-                &pod.annotation.as_ref().unwrap().version,
-            ),
-        }
-    }
-
-    pub fn make_path(&self, model_type: &ModelType, hash: &str, file_name: &str) -> PathBuf {
-        match model_type {
-            ModelType::Pod => self.store.make_path::<Pod>(hash, file_name),
-        }
-    }
-
-    pub fn save_model(&self, model: &Model) -> Result<()> {
-        match model {
-            Model::Pod(pod) => self.store.save_pod(pod),
-        }
-    }
-
-    pub fn load_model(&self, model_type: &ModelType, item_key: &ModelID) -> Result<Model> {
-        match model_type {
-            ModelType::Pod => Ok(Model::Pod(self.store.load_pod(item_key)?)),
-        }
-    }
-
-    pub fn list_model(&self, model_type: &ModelType) -> Result<Vec<ModelInfo>> {
-        match model_type {
-            ModelType::Pod => self.store.list_pod(),
-        }
-    }
-
-    pub fn delete_item(&self, model_type: &ModelType, item_key: &ModelID) -> Result<()> {
-        match model_type {
-            ModelType::Pod => self.store.delete_pod(item_key),
-        }
-    }
-
-    pub fn delete_item_annotation(
-        &mut self,
-        item_type: &ModelType,
-        name: &str,
-        version: &str,
-    ) -> Result<()> {
-        match item_type {
-            ModelType::Pod => Ok(self.store.delete_annotation::<Pod>(name, version)?),
-        }
-    }
-}
-
 pub fn store_test(store_directory: Option<&str>) -> Result<TestLocalStore> {
-    let tmp_directory = tempdir()?.path().to_owned();
+    impl Deref for TestLocalStore {
+        type Target = LocalFileStore;
+        fn deref(&self) -> &Self::Target {
+            &self.store
+        }
+    }
+    impl Drop for TestLocalStore {
+        fn drop(&mut self) {
+            fs::remove_dir_all(self.store.get_directory()).expect("Failed to teardown store.");
+        }
+    }
+    let tmp_directory = String::from(tempdir()?.path().to_string_lossy());
     let store =
-        store_directory.map_or_else(|| LocalFileStore::new(&tmp_directory), LocalFileStore::new);
+        store_directory.map_or_else(|| LocalFileStore::new(tmp_directory), LocalFileStore::new);
+    fs::create_dir_all(store.get_directory())?;
     Ok(TestLocalStore { store })
+}
+
+#[derive(Debug)]
+pub struct TestLocallyStoredPod<'base> {
+    pub store: &'base TestLocalStore,
+    pub pod: Pod,
+}
+
+pub fn add_pod_storage(pod: Pod, store: &TestLocalStore) -> Result<TestLocallyStoredPod> {
+    impl<'base> Deref for TestLocallyStoredPod<'base> {
+        type Target = Pod;
+        fn deref(&self) -> &Self::Target {
+            &self.pod
+        }
+    }
+    impl<'base> Drop for TestLocallyStoredPod<'base> {
+        fn drop(&mut self) {
+            self.store
+                .delete_pod(&ModelID::Hash(self.pod.hash.clone()))
+                .expect("Failed to teardown pod.");
+        }
+    }
+    let pod_with_storage = TestLocallyStoredPod { store, pod };
+    pod_with_storage.store.save_pod(&pod_with_storage)?;
+    Ok(pod_with_storage)
 }

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -80,12 +80,6 @@ pub fn store_test(store_directory: Option<&str>) -> Result<TestStore> {
 // --- helper functions ---
 
 pub fn add_storage<T: TestSetup>(model: T, store: &TestStore) -> Result<TestStoredModel<T>> {
-    impl<'base, T: TestSetup> Deref for TestStoredModel<'base, T> {
-        type Target = T;
-        fn deref(&self) -> &Self::Target {
-            &self.model
-        }
-    }
     impl<'base, T: TestSetup> Drop for TestStoredModel<'base, T> {
         fn drop(&mut self) {
             self.model

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -9,7 +9,7 @@ use orcapod::{
 };
 
 #[test]
-fn verify_hash() -> Result<()> {
+fn hash() -> Result<()> {
     assert_eq!(
         pod_style()?.hash,
         "13d69656d396c272588dd875b2802faee1a56bd985e3c43c7db276a373bc9ddb"
@@ -18,7 +18,7 @@ fn verify_hash() -> Result<()> {
 }
 
 #[test]
-fn verify_pod_to_yaml() -> Result<()> {
+fn pod_to_yaml() -> Result<()> {
     assert_eq!(
         to_yaml::<Pod>(&pod_style()?)?,
         indoc! {"

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,15 +1,17 @@
 #![expect(clippy::panic_in_result_fn, reason = "Panics OK in tests.")]
 
 pub mod fixture;
-use fixture::get_test_pod;
+use fixture::pod_style;
 use indoc::indoc;
-use orcapod::error::Result;
-use orcapod::model::{to_yaml, Pod};
+use orcapod::{
+    error::Result,
+    model::{to_yaml, Pod},
+};
 
 #[test]
 fn verify_hash() -> Result<()> {
     assert_eq!(
-        get_test_pod()?.hash,
+        pod_style()?.hash,
         "13d69656d396c272588dd875b2802faee1a56bd985e3c43c7db276a373bc9ddb"
     );
     Ok(())
@@ -18,7 +20,7 @@ fn verify_hash() -> Result<()> {
 #[test]
 fn verify_pod_to_yaml() -> Result<()> {
     assert_eq!(
-        to_yaml::<Pod>(&get_test_pod()?)?,
+        to_yaml::<Pod>(&pod_style()?)?,
         indoc! {"
             class: pod
             command: tail -f /dev/null

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -12,7 +12,8 @@ use orcapod::{
 fn hash() -> Result<()> {
     assert_eq!(
         pod_style()?.hash,
-        "13d69656d396c272588dd875b2802faee1a56bd985e3c43c7db276a373bc9ddb"
+        "13d69656d396c272588dd875b2802faee1a56bd985e3c43c7db276a373bc9ddb",
+        "Hash didn't match."
     );
     Ok(())
 }
@@ -41,7 +42,8 @@ fn pod_to_yaml() -> Result<()> {
             recommended_memory: 2147483648
             required_gpu: null
             source_commit_url: https://github.com/zenml-io/zenml/tree/0.67.0
-        "}
+        "},
+        "YAML serialization didn't match."
     );
     Ok(())
 }

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -1,154 +1,83 @@
 #![expect(clippy::panic_in_result_fn, reason = "Panics OK in tests.")]
+#![expect(clippy::expect_used, reason = "Expect OK in tests.")]
 
 pub mod fixture;
-use anyhow::Result;
-use fixture::{get_test_item, store_test, ModelType};
-use orcapod::store::ModelID;
-use std::fs;
+use fixture::{add_pod_storage, pod_style, store_test};
+use orcapod::{
+    error::Result,
+    model::{to_yaml, Pod},
+    store::{filestore::LocalFileStore, ModelID, Store},
+};
+use std::{collections::BTreeMap, fs, path::Path};
 use tempfile::tempdir;
 
-#[test]
-fn test_pod_with_file_store() -> Result<()> {
-    test_item_store_with_annotation(&ModelType::Pod)
+fn is_dir_empty(file: &Path, levels_up: usize) -> Option<bool> {
+    Some(
+        file.ancestors()
+            .nth(levels_up)?
+            .read_dir()
+            .ok()?
+            .next()
+            .is_none(),
+    )
 }
 
-#[expect(clippy::too_many_lines, reason = "This will be cut down later")]
-fn test_item_store_with_annotation(item_type: &ModelType) -> Result<()> {
-    let store_directory = tempdir()?.path().to_string_lossy().to_string();
+#[test]
+fn verify_pod_save_and_delete() -> Result<()> {
+    let store_directory = String::from(tempdir()?.path().to_string_lossy());
     {
-        let item = get_test_item(item_type)?;
-        let mut store = store_test(Some(&tempdir()?.path().to_string_lossy()))?; // new tests can just call store_test(None)?
-
-        let annotation_file = store.make_annotation_path(&item);
-
-        let spec_file = store.make_path(item_type, item.get_hash(), "spec.yaml");
-
-        // Test save
-        store.save_model(&item)?;
-        assert!(
-            spec_file.exists(),
-            "Spec file could not be found after item creation"
+        let pod_style = pod_style()?;
+        let store = store_test(Some(&store_directory))?; // new tests can just call store_test(None)?
+        let annotation = pod_style
+            .annotation
+            .as_ref()
+            .expect("Annotation missing from `pod_style`");
+        let annotation_file = store.make_path::<Pod>(
+            &pod_style.hash,
+            &LocalFileStore::make_annotation_relpath(&annotation.name, &annotation.version),
         );
-        assert_eq!(
-            fs::read_to_string(&spec_file)?,
-            item.to_yaml()?,
-            "spec.yaml does not match item.to_yaml, something went wrong during the write"
-        );
-        assert!(
-            annotation_file.exists(),
-            "Cannot find annotation file after saving"
-        );
-
-        // Test load
-        let loaded_item = store.load_model(
-            item_type,
-            &ModelID::NameVer(item.get_name().into(), item.get_version().into()),
-        )?;
-
-        assert!(
-            loaded_item == item,
-            "Loaded item does not match the item was saved"
-        );
-
-        let loaded_item_by_hash =
-            store.load_model(item_type, &ModelID::Hash(item.get_hash().into()))?;
-
-        assert!(
-            loaded_item_by_hash.is_annotation_none(),
-            "Annotation should be empty"
-        );
-
-        // Test list pod
-        // Should only return a result of 1
-        let items = store.list_model(item_type)?;
-        assert!(items.len() == 1, "List item should be length of 1");
-        assert!(
-            items[0].name == item.get_name(),
-            "Item name from list_model didn't match what was saved"
-        );
-        assert!(
-            items[0].version == item.get_version(),
-            "Item version from list_model didn't match what was saved"
-        );
-        assert!(
-            items[0].hash == item.get_hash(),
-            "Item hash from list_model didn't match what was saved"
-        );
-
-        // Add another pod with a new version
-        let mut item_2 = item.clone();
-        item_2.set_name("Second Item Test");
-
-        store.save_model(&item_2)?;
-
-        assert!(
-            store.list_model(item_type)?.len() == 2,
-            "List item should be length of 2"
-        );
-
-        // Test delete
-        store.delete_item_annotation(item_type, item_2.get_name(), item_2.get_version())?;
-
-        assert!(
-            store.list_model(item_type)?.len() == 1,
-            "List item should be length of 1"
-        );
-
-        // Delete the first pod
-        store.delete_item(
-            item_type,
-            &ModelID::NameVer(item.get_name().into(), item.get_version().into()),
-        )?;
-
-        assert!(
-            store.list_model(item_type)?.is_empty(),
-            "List item should be empty"
-        );
-
-        // Test the case with where delete wipes out all annotation
-        store.save_model(&item)?;
-        store.save_model(&item_2)?;
-
-        assert!(
-            store.list_model(item_type)?.len() == 2,
-            "List item should be length of 2"
-        );
-
-        // Delete the entire pod which should get rid of annotation
-        store.delete_item(
-            item_type,
-            &ModelID::NameVer(item.get_name().into(), item.get_version().into()),
-        )?;
-
-        assert!(store.list_model(item_type)?.is_empty(), "List item should be empty after deleting the object itself regardless of how many annotations there are");
-
-        // Test the hash version
-        // Test the case with where delete wipes out all annotation
-        store.save_model(&item)?;
-        store.save_model(&item_2)?;
-
-        assert!(
-            store.list_model(item_type)?.len() == 2,
-            "List item should be length of 2"
-        );
-
-        // Delete the entire pod which should get rid of annotation
-        store.delete_item(item_type, &ModelID::Hash(item.get_hash().into()))?;
-
-        assert!(store.list_model(item_type)?.is_empty(), "List item should be empty after deleting the object itself regardless of how many annotations there are");
-
-        assert!(
-            !spec_file.exists(),
-            "Spec was found when it should have been deleted"
-        );
-        assert!(
-            !annotation_file.exists(),
-            "Annotation file was found when it should have been cleaned up"
-        );
+        let spec_file = store.make_path::<Pod>(&pod_style.hash, LocalFileStore::SPEC_RELPATH);
+        {
+            let pod = add_pod_storage(pod_style, &store)?;
+            assert!(spec_file.exists());
+            assert_eq!(fs::read_to_string(&spec_file)?, to_yaml::<Pod>(&pod)?);
+            assert!(annotation_file.exists());
+        };
+        assert!(!spec_file.exists());
+        assert!(!annotation_file.exists());
+        assert_eq!(is_dir_empty(&spec_file, 2), Some(true));
+        assert_eq!(is_dir_empty(&annotation_file, 3), Some(true));
     };
-    assert!(
-        !fs::exists(&store_directory)?,
-        "Store directory didn't get destory after store object went out of scope"
+    assert!(!fs::exists(&store_directory)?);
+    Ok(())
+}
+
+#[test]
+fn verify_pod_load() -> Result<()> {
+    let store = store_test(None)?;
+    let stored_pod = add_pod_storage(pod_style()?, &store)?;
+    let annotation = stored_pod
+        .annotation
+        .as_ref()
+        .expect("Annotation missing from `pod_style`");
+    let loaded_pod = store.load_pod(&ModelID::Annotation(
+        annotation.name.clone(),
+        annotation.version.clone(),
+    ))?;
+    assert_eq!(loaded_pod, stored_pod.pod);
+    Ok(())
+}
+
+#[test]
+fn verify_pod_list() -> Result<()> {
+    let store = store_test(None)?;
+    assert_eq!(
+        store.list_pod()?,
+        BTreeMap::from([
+            ("hash".to_owned(), vec![],),
+            ("name".to_owned(), vec![],),
+            ("version".to_owned(), vec![],),
+        ])
     );
     Ok(())
 }

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -2,7 +2,7 @@
 #![expect(clippy::expect_used, reason = "Expect OK in tests.")]
 
 pub mod fixture;
-use fixture::{add_pod_storage, pod_style, store_test};
+use fixture::{add_storage, pod_style, store_test};
 use orcapod::{
     error::Result,
     model::{to_yaml, Pod},
@@ -38,7 +38,7 @@ fn verify_pod_save_and_delete() -> Result<()> {
         );
         let spec_file = store.make_path::<Pod>(&pod_style.hash, LocalFileStore::SPEC_RELPATH);
         {
-            let pod = add_pod_storage(pod_style, &store)?;
+            let pod = add_storage(pod_style, &store)?;
             assert!(spec_file.exists());
             assert_eq!(fs::read_to_string(&spec_file)?, to_yaml::<Pod>(&pod)?);
             assert!(annotation_file.exists());
@@ -55,7 +55,7 @@ fn verify_pod_save_and_delete() -> Result<()> {
 #[test]
 fn verify_pod_load() -> Result<()> {
     let store = store_test(None)?;
-    let stored_pod = add_pod_storage(pod_style()?, &store)?;
+    let stored_pod = add_storage(pod_style()?, &store)?;
     let annotation = stored_pod
         .annotation
         .as_ref()
@@ -64,7 +64,7 @@ fn verify_pod_load() -> Result<()> {
         annotation.name.clone(),
         annotation.version.clone(),
     ))?;
-    assert_eq!(loaded_pod, stored_pod.pod);
+    assert_eq!(loaded_pod, stored_pod.model);
     Ok(())
 }
 


### PR DESCRIPTION
Following the merge of #34 , this PR applies the ideas in my review.

Below is a summary of all the features that were accomplished across both PRs.

## Features

- Use generic methods
- Make deletes explicit (`delete_annotation`, `delete_pod`), remove checks in `delete_pod` since deletes are explicit, and prevent deletion of the last annotation in `delete_annotation`
- Change annotation save path (`annotation` subdirectory in model directory)
- Make annotation optional for `load_pod` and `delete_pod` but required for `save_pod`
- Support loading or deleting pod from a hash or name/version (via `ModelID`)
- Make `Result` pub
- Expose `LocalFileStore.directory` only via getter
- Use `impl AsRef<Path>` as opposed to `impl Into<PathBuf>`
- Apply map to format desired in `list_model`. Currently, just passing through `Vec<ModelInfo>`.

## Minor Improvements

- Make path builder more general
- Use a `Vec<ModelInfo>` internally when parsing annotation path
- Compile regex once instead of in each iteration (moved out of map via [move](https://doc.rust-lang.org/std/keyword.move.html))
- Parse `class` in regex
- Make `save_file` more flexible
- Use YAML content as opposed to files in `from_yaml`
- Add `lookup_hash` based on `name`/`version`
- Remove `get_version_map` since unneeded with explicit deletes
- Remove `FileHasNoParent` error
- Rename `parse_annotation_path(path)` -> `find_annotation(glob_pattern)` to improve readability.
- Add `snake_case` utility
- Simplify util methods
- Simplify `to_yaml` usage
- Update docs

## Tests

- ~Removed tests introduced in #34 so they are addressed separately~ Tests have been reworked to align with the original fixture design. Includes tests from #34.  Improves code coverage from ~70% -> ~72%.
- Allow `expect` usage in tests to simplify
- Add `pod_load` test
- Add equality support in `Pod`
- Add test for `list_pod` when none exist yet
- Create store dir in fixture when initializing so drop doesn't panic
- Make empty dir check in tests take an arg for # of levels up
- Pull out implementations from fixture functions

## Dev Improvements

- Make spec/annotation paths and filenames easier to change in the future
- Add spell checker w/ a word ignore list
- Fix typos