### PR TITLE
Reorg in preparation for UniFFI client

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # DevContainer image
-FROM rust:1.85-slim
+FROM rust:1.86-slim
 RUN \
     adduser --system --disabled-password --shell /bin/bash --home /home/vscode vscode && \
     # install docker

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Rust + components
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85
+          toolchain: 1.86
           components: rustfmt,clippy
       - name: Install Rust code coverage
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ missing_asserts_for_indexing = { level = "allow", priority = 127 }     # missing
 missing_docs_in_private_items = { level = "allow", priority = 127 }    # missing docs on private ok
 missing_inline_in_public_items = { level = "allow", priority = 127 }   # let rust compiler determine best inline logic
 missing_trait_methods = { level = "allow", priority = 127 }            # allow in favor of rustc `implement the missing item`
+multiple_inherent_impl = { level = "allow", priority = 127 }           # required in best practice to limit exposure over UniFFI
 must_use_candidate = { level = "allow", priority = 127 }               # omitting #[must_use] ok
 mod_module_files = { level = "allow", priority = 127 }                 # mod directories ok
 non_ascii_literal = { level = "allow", priority = 127 }                # non-ascii char in string literal ok

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,8 @@
         "nanocore",
         "numpy",
         "graphviz",
+        "uniffi",
+        "cffi"
     ],
     "ignoreWords": [
         "relpath",

--- a/src/core/crypto.rs
+++ b/src/core/crypto.rs
@@ -1,7 +1,9 @@
 use crate::{
-    error::Result,
-    model::{Blob, BlobKind},
-    util::get,
+    core::util::get,
+    uniffi::{
+        error::Result,
+        model::{Blob, BlobKind},
+    },
 };
 use serde_yaml;
 use sha2::{Digest as _, Sha256};
@@ -21,7 +23,7 @@ use std::{
     clippy::indexing_slicing,
     reason = "Reading less than 0 is impossible."
 )]
-pub fn hash_stream(stream: &mut impl Read) -> Result<String> {
+pub(crate) fn hash_stream(stream: &mut impl Read) -> Result<String> {
     const BUFFER_SIZE: usize = 8 << 10; // 8KB chunks to match with page size typically found
     let mut hash = Sha256::new();
 
@@ -79,7 +81,7 @@ pub fn hash_dir(dirpath: impl AsRef<Path>) -> Result<String> {
 /// # Errors
 ///
 /// Will return error if hashing fails on file or directory.
-pub fn hash_blob(
+pub(crate) fn hash_blob(
     namespace_lookup: &HashMap<String, PathBuf, RandomState>,
     blob: Blob,
 ) -> Result<Blob> {

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1,4 +1,4 @@
-use crate::uniffi::error::OrcaError;
+use crate::uniffi::error::{Kind, OrcaError};
 use bollard::errors::Error as BollardError;
 use glob;
 use serde_json;
@@ -6,49 +6,8 @@ use serde_yaml;
 use std::{
     fmt::{self, Display, Formatter},
     io, path,
-    path::PathBuf,
 };
-use thiserror::Error;
-/// Possible errors you may encounter.
-#[derive(Error, Debug)]
-pub enum Kind {
-    #[error(
-        "Received an empty response when attempting to load the alternate container image file: {path}."
-    )]
-    EmptyResponseWhenLoadingContainerAltImage { path: PathBuf },
-    #[error("Out of generated random names.")]
-    GeneratedNamesOverflow,
-    #[error("Path missing a file or directory name: {path}.")]
-    InvalidPath { path: PathBuf },
-    #[error("An invalid datetime was set for pod result for pod job (hash: {pod_job_hash}).")]
-    InvalidPodResultTerminatedDatetime { pod_job_hash: String },
-    #[error("Key '{key}' was not found in map.")]
-    KeyMissing { key: String },
-    #[error("No annotation found for `{name}:{version}` {class}.")]
-    NoAnnotationFound {
-        class: String,
-        name: String,
-        version: String,
-    },
-    #[error("No known container names.")]
-    NoContainerNames,
-    #[error("No corresponding pod run found for pod job (hash: {pod_job_hash}).")]
-    NoMatchingPodRun { pod_job_hash: String },
-    #[error("No tags found in provided container alternate image: {path}.")]
-    NoTagFoundInContainerAltImage { path: PathBuf },
-    #[error(transparent)]
-    BollardError(#[from] BollardError),
-    #[error(transparent)]
-    GlobPatternError(#[from] glob::PatternError),
-    #[error(transparent)]
-    IoError(#[from] io::Error),
-    #[error(transparent)]
-    PathPrefixError(#[from] path::StripPrefixError),
-    #[error(transparent)]
-    SerdeJsonError(#[from] serde_json::Error),
-    #[error(transparent)]
-    SerdeYamlError(#[from] serde_yaml::Error),
-}
+
 impl Display for OrcaError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.kind)

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1,3 +1,4 @@
+use crate::uniffi::error::OrcaError;
 use bollard::errors::Error as BollardError;
 use glob;
 use serde_json;
@@ -6,14 +7,11 @@ use std::{
     fmt::{self, Display, Formatter},
     io, path,
     path::PathBuf,
-    result,
 };
 use thiserror::Error;
-/// Shorthand for a Result that returns an `OrcaError`.
-pub type Result<T> = result::Result<T, OrcaError>;
 /// Possible errors you may encounter.
 #[derive(Error, Debug)]
-pub(crate) enum Kind {
+pub enum Kind {
     #[error(
         "Received an empty response when attempting to load the alternate container image file: {path}."
     )]
@@ -50,21 +48,6 @@ pub(crate) enum Kind {
     SerdeJsonError(#[from] serde_json::Error),
     #[error(transparent)]
     SerdeYamlError(#[from] serde_yaml::Error),
-}
-/// A stable error API interface.
-#[derive(Error, Debug)]
-pub struct OrcaError {
-    kind: Kind,
-}
-impl OrcaError {
-    /// Returns `true` if the error was caused by an invalid model annotation.
-    pub const fn is_invalid_annotation(&self) -> bool {
-        matches!(self.kind, Kind::NoAnnotationFound { .. })
-    }
-    /// Returns `true` if the error was caused by querying a purged pod run.
-    pub const fn is_purged_pod_run(&self) -> bool {
-        matches!(self.kind, Kind::NoMatchingPodRun { .. })
-    }
 }
 impl Display for OrcaError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,8 @@
+/// State change verification via cryptographic utilities.
+pub mod crypto;
+pub(crate) mod error;
+/// Components of the data model.
+pub mod model;
+pub(crate) mod orchestrator;
+pub(crate) mod store;
+pub(crate) mod util;

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -1,0 +1,90 @@
+use crate::{
+    core::util::get_type_name,
+    uniffi::{
+        error::Result,
+        model::{Pod, PodJob},
+    },
+};
+use heck::ToSnakeCase as _;
+use serde::{Deserialize as _, Deserializer, Serialize, Serializer};
+use serde_yaml;
+use std::{
+    collections::{BTreeMap, HashMap},
+    result,
+};
+/// Converts a model instance into a consistent yaml.
+///
+/// # Errors
+///
+/// Will return `Err` if there is an issue converting an `instance` into YAML (w/o annotation).
+pub fn to_yaml<T: Serialize>(instance: &T) -> Result<String> {
+    let mut yaml = serde_yaml::to_string(instance)?;
+    yaml.insert_str(
+        0,
+        &format!("class: {}\n", get_type_name::<T>().to_snake_case()),
+    ); // replace class at top
+
+    Ok(yaml)
+}
+
+pub(crate) fn serialize_hashmap<S, K: Ord + Serialize, V: Serialize>(
+    map: &HashMap<K, V>,
+    serializer: S,
+) -> result::Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let sorted = map.iter().collect::<BTreeMap<_, _>>();
+    sorted.serialize(serializer)
+}
+
+#[expect(clippy::ref_option, reason = "Serde requires this signature.")]
+pub(crate) fn serialize_hashmap_option<S, K: Ord + Serialize, V: Serialize>(
+    map_option: &Option<HashMap<K, V>>,
+    serializer: S,
+) -> result::Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let sorted = map_option
+        .as_ref()
+        .map(|map| map.iter().collect::<BTreeMap<_, _>>());
+    sorted.serialize(serializer)
+}
+
+pub(crate) fn serialize_pod<S>(pod: &Pod, serializer: S) -> result::Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&pod.hash)
+}
+
+pub(crate) fn deserialize_pod<'de, D>(deserializer: D) -> result::Result<Pod, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Pod {
+        hash: String::deserialize(deserializer)?,
+        ..Pod::default()
+    })
+}
+
+pub(crate) fn serialize_pod_job<S>(
+    pod_job: &PodJob,
+    serializer: S,
+) -> result::Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&pod_job.hash)
+}
+
+pub(crate) fn deserialize_pod_job<'de, D>(deserializer: D) -> result::Result<PodJob, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(PodJob {
+        hash: String::deserialize(deserializer)?,
+        ..PodJob::default()
+    })
+}

--- a/src/core/orchestrator/docker.rs
+++ b/src/core/orchestrator/docker.rs
@@ -1,7 +1,7 @@
 use crate::{
-    core::{error::Kind, util::get},
+    core::util::get,
     uniffi::{
-        error::{OrcaError, Result},
+        error::{Kind, OrcaError, Result},
         model::{Input, PodJob},
         orchestrator::{RunInfo, Status, docker::LocalDockerOrchestrator},
     },

--- a/src/core/orchestrator/docker.rs
+++ b/src/core/orchestrator/docker.rs
@@ -1,23 +1,17 @@
 use crate::{
-    error::{Kind, OrcaError, Result},
-    model::{Input, Pod, PodJob, PodResult},
-    orchestrator::{ImageKind, Orchestrator, PodRun, RunInfo, Status},
-    util::get,
+    core::{error::Kind, util::get},
+    uniffi::{
+        error::{OrcaError, Result},
+        model::{Input, PodJob},
+        orchestrator::{RunInfo, Status, docker::LocalDockerOrchestrator},
+    },
 };
 use bollard::{
-    Docker,
-    container::{
-        Config, CreateContainerOptions, ListContainersOptions, RemoveContainerOptions,
-        StartContainerOptions, WaitContainerOptions,
-    },
-    image::{CreateImageOptions, ImportImageOptions},
+    container::{Config, CreateContainerOptions, ListContainersOptions},
     models::{ContainerStateStatusEnum, HostConfig},
 };
 use chrono::DateTime;
-use futures_util::{
-    future::join_all,
-    stream::{StreamExt as _, TryStreamExt as _},
-};
+use futures_util::future::join_all;
 use names::{Generator, Name};
 use regex::Regex;
 use std::{
@@ -26,205 +20,9 @@ use std::{
     path::{self, PathBuf},
     sync::LazyLock,
 };
-use tokio::{fs::File, runtime::Runtime};
-use tokio_util::{
-    bytes::{Bytes, BytesMut},
-    codec::{BytesCodec, FramedRead},
-};
-
-/// Support for an orchestration engine using a local docker installation.
-#[derive(Debug)]
-pub struct LocalDockerOrchestrator {
-    api: Docker,
-    async_driver: Runtime,
-}
-
-impl Orchestrator for LocalDockerOrchestrator {
-    fn start_with_altimage_blocking(
-        &self,
-        namespace_lookup: &HashMap<String, PathBuf>,
-        pod_job: &PodJob,
-        image: &ImageKind,
-    ) -> Result<PodRun> {
-        self.async_driver
-            .block_on(self.start_with_altimage(namespace_lookup, pod_job, image))
-    }
-    fn start_blocking(
-        &self,
-        namespace_lookup: &HashMap<String, PathBuf>,
-        pod_job: &PodJob,
-    ) -> Result<PodRun> {
-        self.async_driver
-            .block_on(self.start(namespace_lookup, pod_job))
-    }
-    fn list_blocking(&self) -> Result<Vec<PodRun>> {
-        self.async_driver.block_on(self.list())
-    }
-    fn delete_blocking(&self, pod_run: &PodRun) -> Result<()> {
-        self.async_driver.block_on(self.delete(pod_run))
-    }
-    fn get_info_blocking(&self, pod_run: &PodRun) -> Result<RunInfo> {
-        self.async_driver.block_on(self.get_info(pod_run))
-    }
-    fn get_result_blocking(&self, pod_run: &PodRun) -> Result<PodResult> {
-        self.async_driver.block_on(self.get_result(pod_run))
-    }
-    #[expect(
-        clippy::try_err,
-        reason = r#"
-        - `map_err` workaround needed since `import_image_stream` requires resolved bytes
-        - Raising an error manually on occurrence to halt so we don't just ignore
-        - Should not get as far as `Ok(_)`
-        "#
-    )]
-    async fn start_with_altimage(
-        &self,
-        namespace_lookup: &HashMap<String, PathBuf>,
-        pod_job: &PodJob,
-        image: &ImageKind,
-    ) -> Result<PodRun> {
-        let (assigned_name, container_options, container_config) = match image {
-            ImageKind::Published(remote_image) => Self::prepare_container_start_inputs(
-                namespace_lookup,
-                pod_job,
-                remote_image.clone(),
-            )?,
-            ImageKind::Tarball(image_info) => {
-                let location = namespace_lookup[&image_info.namespace].join(&image_info.path);
-                let byte_stream = FramedRead::new(File::open(&location).await?, BytesCodec::new())
-                    .map_err(|err| -> Result<BytesMut> {
-                        let resolved_error = Err::<BytesMut, OrcaError>(err.into())?;
-                        Ok(resolved_error)
-                    })
-                    .map(|result| result.ok().map_or(Bytes::new(), BytesMut::freeze));
-                let mut stream =
-                    self.api
-                        .import_image_stream(ImportImageOptions::default(), byte_stream, None);
-                let mut local_image = String::new();
-                while let Some(response) = stream.next().await {
-                    local_image = RE_IMAGE_TAG
-                        .captures_iter(&response?.stream.ok_or(OrcaError::from(
-                            Kind::EmptyResponseWhenLoadingContainerAltImage {
-                                path: location.clone(),
-                            },
-                        ))?)
-                        .find_map(|x| x.name("image").map(|name| name.as_str().to_owned()))
-                        .ok_or(OrcaError::from(Kind::NoTagFoundInContainerAltImage {
-                            path: location.clone(),
-                        }))?;
-                }
-                Self::prepare_container_start_inputs(
-                    namespace_lookup,
-                    pod_job,
-                    local_image.clone(),
-                )?
-            }
-        };
-        self.api
-            .create_container(container_options, container_config)
-            .await?;
-        self.api
-            .start_container(&assigned_name, None::<StartContainerOptions<String>>)
-            .await?;
-        Ok(PodRun::new::<Self>(pod_job, assigned_name))
-    }
-    async fn start(
-        &self,
-        namespace_lookup: &HashMap<String, PathBuf>,
-        pod_job: &PodJob,
-    ) -> Result<PodRun> {
-        let image_options = Some(CreateImageOptions {
-            from_image: pod_job.pod.image.clone(),
-            ..Default::default()
-        });
-        self.api
-            .create_image(image_options, None, None)
-            .try_collect::<Vec<_>>()
-            .await?;
-        self.start_with_altimage(
-            namespace_lookup,
-            pod_job,
-            &ImageKind::Published(pod_job.pod.image.clone()),
-        )
-        .await
-    }
-    async fn list(&self) -> Result<Vec<PodRun>> {
-        self.list_containers(HashMap::from([(
-            "label".to_owned(),
-            vec!["org.orcapod=true".to_owned()],
-        )]))
-        .await?
-        .map(|(assigned_name, run_info)| {
-            let mut pod: Pod = serde_json::from_str(get(&run_info.labels, "org.orcapod.pod")?)?;
-            pod.annotation =
-                serde_json::from_str(get(&run_info.labels, "org.orcapod.pod.annotation")?)?;
-            pod.hash
-                .clone_from(get(&run_info.labels, "org.orcapod.pod.hash")?);
-            let mut pod_job: PodJob =
-                serde_json::from_str(get(&run_info.labels, "org.orcapod.pod_job")?)?;
-            pod_job.annotation =
-                serde_json::from_str(get(&run_info.labels, "org.orcapod.pod_job.annotation")?)?;
-            pod_job
-                .hash
-                .clone_from(get(&run_info.labels, "org.orcapod.pod_job.hash")?);
-            pod_job.pod = pod;
-            Ok(PodRun::new::<Self>(&pod_job, assigned_name))
-        })
-        .collect()
-    }
-    async fn delete(&self, pod_run: &PodRun) -> Result<()> {
-        self.api
-            .remove_container(
-                &pod_run.assigned_name,
-                Some(RemoveContainerOptions {
-                    force: true,
-                    ..Default::default()
-                }),
-            )
-            .await?;
-        Ok(())
-    }
-    async fn get_info(&self, pod_run: &PodRun) -> Result<RunInfo> {
-        let labels = vec![
-            "org.orcapod=true".to_owned(),
-            format!(
-                "org.orcapod.pod_job.annotation={}",
-                serde_json::to_string(&pod_run.pod_job.annotation)?
-            ),
-            format!("org.orcapod.pod_job.hash={}", pod_run.pod_job.hash),
-        ];
-        let (_, run_info) = self
-            .list_containers(HashMap::from([("label".to_owned(), labels)]))
-            .await?
-            .next()
-            .ok_or(OrcaError::from(Kind::NoMatchingPodRun {
-                pod_job_hash: pod_run.pod_job.hash.clone(),
-            }))?;
-        Ok(run_info)
-    }
-    async fn get_result(&self, pod_run: &PodRun) -> Result<PodResult> {
-        self.api
-            .wait_container(&pod_run.assigned_name, None::<WaitContainerOptions<String>>)
-            .try_collect::<Vec<_>>()
-            .await?;
-        let result_info = self.get_info(pod_run).await?;
-        PodResult::new(
-            None,
-            pod_run.pod_job.clone(),
-            pod_run.assigned_name.clone(),
-            result_info.status,
-            result_info.created,
-            result_info.terminated.ok_or(OrcaError::from(
-                Kind::InvalidPodResultTerminatedDatetime {
-                    pod_job_hash: pod_run.pod_job.hash.clone(),
-                },
-            ))?,
-        )
-    }
-}
 
 #[expect(clippy::expect_used, reason = "Valid static regex")]
-static RE_IMAGE_TAG: LazyLock<Regex> = LazyLock::new(|| {
+pub static RE_IMAGE_TAG: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?x)
                 \s
@@ -236,18 +34,6 @@ static RE_IMAGE_TAG: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 impl LocalDockerOrchestrator {
-    /// How to create a local docker orchestrator with an absolute path on docker host where binds
-    /// will be mounted from.
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if there is an issue creating a local docker orchestrator.
-    pub fn new() -> Result<Self> {
-        Ok(Self {
-            api: Docker::connect_with_local_defaults()?,
-            async_driver: Runtime::new()?,
-        })
-    }
     fn prepare_mount_binds(
         namespace_lookup: &HashMap<String, PathBuf>,
         pod_job: &PodJob,
@@ -321,7 +107,7 @@ impl LocalDockerOrchestrator {
         - Pod commands will always have at least 1 element
         "#
     )]
-    fn prepare_container_start_inputs(
+    pub(crate) fn prepare_container_start_inputs(
         namespace_lookup: &HashMap<String, PathBuf>,
         pod_job: &PodJob,
         image: String,
@@ -404,7 +190,7 @@ impl LocalDockerOrchestrator {
         - Containers will always have at least 1 name with at least 2 characters
         "#
     )]
-    async fn list_containers(
+    pub(crate) async fn list_containers(
         &self,
         filters: HashMap<String, Vec<String>>, // https://docs.rs/bollard/latest/bollard/container/struct.ListContainersOptions.html#structfield.filters
     ) -> Result<impl Iterator<Item = (String, RunInfo)>> {

--- a/src/core/orchestrator/mod.rs
+++ b/src/core/orchestrator/mod.rs
@@ -1,0 +1,19 @@
+use crate::{
+    core::util::get_type_name,
+    uniffi::{
+        model::PodJob,
+        orchestrator::{Orchestrator, PodRun},
+    },
+};
+
+impl PodRun {
+    pub(crate) fn new<O: Orchestrator>(pod_job: &PodJob, assigned_name: String) -> Self {
+        Self {
+            pod_job: pod_job.clone(),
+            orchestrator_source: get_type_name::<O>(),
+            assigned_name,
+        }
+    }
+}
+
+pub mod docker;

--- a/src/core/store/filestore.rs
+++ b/src/core/store/filestore.rs
@@ -1,7 +1,7 @@
 use crate::{
-    core::{error::Kind, model::to_yaml, util::get_type_name},
+    core::{model::to_yaml, util::get_type_name},
     uniffi::{
-        error::{OrcaError, Result},
+        error::{Kind, OrcaError, Result},
         model::Annotation,
         store::{ModelID, ModelInfo, Store as _, filestore::LocalFileStore},
     },

--- a/src/core/store/filestore.rs
+++ b/src/core/store/filestore.rs
@@ -1,8 +1,10 @@
 use crate::{
-    error::{Kind, OrcaError, Result},
-    model::{Annotation, Pod, PodJob, PodResult, to_yaml},
-    store::{ModelID, ModelInfo, Store},
-    util::get_type_name,
+    core::{error::Kind, model::to_yaml, util::get_type_name},
+    uniffi::{
+        error::{OrcaError, Result},
+        model::Annotation,
+        store::{ModelID, ModelInfo, Store as _, filestore::LocalFileStore},
+    },
 };
 use colored::Colorize as _;
 use glob::glob;
@@ -15,72 +17,6 @@ use std::{
     path::{Path, PathBuf},
     sync::LazyLock,
 };
-/// Support for a storage backend on a local filesystem directory.
-#[derive(Debug)]
-pub struct LocalFileStore {
-    /// A local path to a directory where store will be located.
-    directory: PathBuf,
-}
-
-impl Store for LocalFileStore {
-    fn save_pod(&self, pod: &Pod) -> Result<()> {
-        self.save_model(pod, &pod.hash, pod.annotation.as_ref())
-    }
-    fn load_pod(&self, model_id: &ModelID) -> Result<Pod> {
-        let (mut pod, annotation, hash) = self.load_model::<Pod>(model_id)?;
-        pod.annotation = annotation;
-        pod.hash = hash;
-        Ok(pod)
-    }
-    fn list_pod(&self) -> Result<Vec<ModelInfo>> {
-        self.list_model::<Pod>()
-    }
-    fn delete_pod(&self, model_id: &ModelID) -> Result<()> {
-        self.delete_model::<Pod>(model_id)
-    }
-    fn save_pod_job(&self, pod_job: &PodJob) -> Result<()> {
-        self.save_pod(&pod_job.pod)?;
-        self.save_model(pod_job, &pod_job.hash, pod_job.annotation.as_ref())
-    }
-    fn load_pod_job(&self, model_id: &ModelID) -> Result<PodJob> {
-        let (mut pod_job, annotation, hash) = self.load_model::<PodJob>(model_id)?;
-        pod_job.annotation = annotation;
-        pod_job.hash = hash;
-        pod_job.pod = self.load_pod(&ModelID::Hash(pod_job.pod.hash))?;
-        Ok(pod_job)
-    }
-    fn list_pod_job(&self) -> Result<Vec<ModelInfo>> {
-        self.list_model::<PodJob>()
-    }
-    fn delete_pod_job(&self, model_id: &ModelID) -> Result<()> {
-        self.delete_model::<PodJob>(model_id)
-    }
-    fn save_pod_result(&self, pod_result: &PodResult) -> Result<()> {
-        self.save_pod_job(&pod_result.pod_job)?;
-        self.save_model(pod_result, &pod_result.hash, pod_result.annotation.as_ref())
-    }
-    fn load_pod_result(&self, model_id: &ModelID) -> Result<PodResult> {
-        let (mut pod_result, annotation, hash) = self.load_model::<PodResult>(model_id)?;
-        pod_result.annotation = annotation;
-        pod_result.hash = hash;
-        pod_result.pod_job = self.load_pod_job(&ModelID::Hash(pod_result.pod_job.hash))?;
-        Ok(pod_result)
-    }
-    fn list_pod_result(&self) -> Result<Vec<ModelInfo>> {
-        self.list_model::<PodResult>()
-    }
-    fn delete_pod_result(&self, model_id: &ModelID) -> Result<()> {
-        self.delete_model::<PodResult>(model_id)
-    }
-    fn delete_annotation<T>(&self, name: &str, version: &str) -> Result<()> {
-        let hash = self.lookup_hash::<T>(name, version)?;
-        let annotation_file =
-            self.make_path::<T>(&hash, Self::make_annotation_relpath(name, version));
-        fs::remove_file(&annotation_file)?;
-
-        Ok(())
-    }
-}
 
 #[expect(clippy::expect_used, reason = "Valid static regex")]
 static RE_MODEL_METADATA: LazyLock<Regex> = LazyLock::new(|| {
@@ -117,7 +53,7 @@ impl LocalFileStore {
     pub fn make_path<T>(&self, hash: &str, relpath: impl AsRef<Path>) -> PathBuf {
         PathBuf::from(format!(
             "{}/{}/{}/{}",
-            self.directory.to_string_lossy(),
+            self.get_directory().to_string_lossy(),
             Self::MODEL_NAMESPACE,
             get_type_name::<T>().to_snake_case(),
             hash
@@ -139,18 +75,12 @@ impl LocalFileStore {
         });
         Ok(paths)
     }
-    /// Get the directory where store is located.
-    pub fn get_directory(&self) -> &Path {
-        &self.directory
-    }
-    /// Construct a local file store instance in a specific directory.
-    pub fn new(directory: impl AsRef<Path>) -> Self {
-        Self {
-            directory: directory.as_ref().into(),
-        }
-    }
-
-    fn lookup_hash<T>(&self, name: &str, version: &str) -> Result<String> {
+    /// Find hash using name and version.
+    ///
+    /// # Errors
+    ///
+    /// Will return error if unable to find.
+    pub(crate) fn lookup_hash<T>(&self, name: &str, version: &str) -> Result<String> {
         let model_info = Self::find_model_metadata(
             &self.make_path::<T>("*", Self::make_annotation_relpath(name, version)),
         )?
@@ -172,8 +102,12 @@ impl LocalFileStore {
         fs::write(file, content)?;
         Ok(())
     }
-
-    fn save_model<T: Serialize>(
+    /// How any model is stored.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there is an issue storing the model.
+    pub(crate) fn save_model<T: Serialize>(
         &self,
         model: &T,
         hash: &str,
@@ -220,8 +154,13 @@ impl LocalFileStore {
         }
         Ok(())
     }
-
-    fn load_model<T: DeserializeOwned>(
+    /// How to load any stored model into an instance.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there is an issue loading the model from the store using `name` and
+    /// `version`.
+    pub(crate) fn load_model<T: DeserializeOwned>(
         &self,
         model_id: &ModelID,
     ) -> Result<(T, Option<Annotation>, String)> {
@@ -247,12 +186,21 @@ impl LocalFileStore {
             }
         }
     }
-
-    fn list_model<T>(&self) -> Result<Vec<ModelInfo>> {
+    /// How to query any stored models.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there is an issue querying metadata from existing models in the store.
+    pub(crate) fn list_model<T>(&self) -> Result<Vec<ModelInfo>> {
         Ok(Self::find_model_metadata(&self.make_path::<T>("**", "*"))?.collect())
     }
-
-    fn delete_model<T>(&self, model_id: &ModelID) -> Result<()> {
+    /// How to explicitly delete any stored model and all associated annotations (does not propagate).
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there is an issue deleting a model from the store using `name` and
+    /// `version`.
+    pub(crate) fn delete_model<T>(&self, model_id: &ModelID) -> Result<()> {
         // assumes propagate = false
         let hash = match model_id {
             ModelID::Hash(hash) => hash,

--- a/src/core/store/filestore.rs
+++ b/src/core/store/filestore.rs
@@ -53,7 +53,7 @@ impl LocalFileStore {
     pub fn make_path<T>(&self, hash: &str, relpath: impl AsRef<Path>) -> PathBuf {
         PathBuf::from(format!(
             "{}/{}/{}/{}",
-            self.get_directory().to_string_lossy(),
+            self.directory.to_string_lossy(),
             Self::MODEL_NAMESPACE,
             get_type_name::<T>().to_snake_case(),
             hash

--- a/src/core/store/mod.rs
+++ b/src/core/store/mod.rs
@@ -1,0 +1,1 @@
+pub mod filestore;

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -1,4 +1,4 @@
-use crate::error::{Kind, Result};
+use crate::{core::error::Kind, uniffi::error::Result};
 use std::{any::type_name, collections::HashMap};
 
 #[expect(

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -1,4 +1,4 @@
-use crate::{core::error::Kind, uniffi::error::Result};
+use crate::uniffi::error::{Kind, Result};
 use std::{any::type_name, collections::HashMap};
 
 #[expect(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,7 @@
 //! Intuitive compute pipeline orchestration with reproducibility, performance, and scalability in
 //! mind.
 
-/// State change verification via cryptographic utilities.
-pub mod crypto;
-/// Error handling based on enumeration.
-pub mod error;
-/// Components of the data model.
-pub mod model;
-/// Interface into container orchestration engine.
-pub mod orchestrator;
-/// Data persistence provided by a store backend.
-pub mod store;
-mod util;
+/// Pure Rust source.
+pub mod core;
+/// Exposed `CFFI` client based on `UniFFI`.
+pub mod uniffi;

--- a/src/uniffi/error.rs
+++ b/src/uniffi/error.rs
@@ -1,13 +1,61 @@
-use crate::core::error::Kind;
-use std::result;
+use bollard::errors::Error as BollardError;
+use std::{
+    io,
+    path::{self, PathBuf},
+    result,
+};
 use thiserror::Error;
 /// Shorthand for a Result that returns an `OrcaError`.
 pub type Result<T> = result::Result<T, OrcaError>;
+/// Possible errors you may encounter.
+#[derive(Error, Debug)]
+pub(crate) enum Kind {
+    #[error(
+        "Received an empty response when attempting to load the alternate container image file: {path}."
+    )]
+    EmptyResponseWhenLoadingContainerAltImage { path: PathBuf },
+    #[error("Out of generated random names.")]
+    GeneratedNamesOverflow,
+    #[error("Path missing a file or directory name: {path}.")]
+    InvalidPath { path: PathBuf },
+    #[error("An invalid datetime was set for pod result for pod job (hash: {pod_job_hash}).")]
+    InvalidPodResultTerminatedDatetime { pod_job_hash: String },
+    #[error("Key '{key}' was not found in map.")]
+    KeyMissing { key: String },
+    #[error("No annotation found for `{name}:{version}` {class}.")]
+    NoAnnotationFound {
+        class: String,
+        name: String,
+        version: String,
+    },
+    #[error("No known container names.")]
+    NoContainerNames,
+    #[error("No corresponding pod run found for pod job (hash: {pod_job_hash}).")]
+    NoMatchingPodRun { pod_job_hash: String },
+    #[error("No tags found in provided container alternate image: {path}.")]
+    NoTagFoundInContainerAltImage { path: PathBuf },
+    #[error(transparent)]
+    BollardError(#[from] BollardError),
+    #[error(transparent)]
+    GlobPatternError(#[from] glob::PatternError),
+    #[error(transparent)]
+    IoError(#[from] io::Error),
+    #[error(transparent)]
+    PathPrefixError(#[from] path::StripPrefixError),
+    #[error(transparent)]
+    SerdeJsonError(#[from] serde_json::Error),
+    #[error(transparent)]
+    SerdeYamlError(#[from] serde_yaml::Error),
+}
 /// A stable error API interface.
+#[expect(
+    clippy::field_scoped_visibility_modifiers,
+    reason = "Allow access from `core::error`."
+)]
 #[derive(Error, Debug)]
 pub struct OrcaError {
     /// Type of error returned.
-    pub kind: Kind,
+    pub(crate) kind: Kind,
 }
 impl OrcaError {
     /// Returns `true` if the error was caused by an invalid model annotation.

--- a/src/uniffi/error.rs
+++ b/src/uniffi/error.rs
@@ -1,0 +1,21 @@
+use crate::core::error::Kind;
+use std::result;
+use thiserror::Error;
+/// Shorthand for a Result that returns an `OrcaError`.
+pub type Result<T> = result::Result<T, OrcaError>;
+/// A stable error API interface.
+#[derive(Error, Debug)]
+pub struct OrcaError {
+    /// Type of error returned.
+    pub kind: Kind,
+}
+impl OrcaError {
+    /// Returns `true` if the error was caused by an invalid model annotation.
+    pub const fn is_invalid_annotation(&self) -> bool {
+        matches!(self.kind, Kind::NoAnnotationFound { .. })
+    }
+    /// Returns `true` if the error was caused by querying a purged pod run.
+    pub const fn is_purged_pod_run(&self) -> bool {
+        matches!(self.kind, Kind::NoMatchingPodRun { .. })
+    }
+}

--- a/src/uniffi/mod.rs
+++ b/src/uniffi/mod.rs
@@ -1,0 +1,8 @@
+/// Error handling.
+pub mod error;
+/// Components of the data model.
+pub mod model;
+/// Interface into container orchestration engine.
+pub mod orchestrator;
+/// Data persistence provided by a store backend.
+pub mod store;

--- a/src/uniffi/model.rs
+++ b/src/uniffi/model.rs
@@ -1,56 +1,15 @@
 use crate::{
-    crypto::{hash_blob, hash_buffer},
-    error::Result,
-    orchestrator::Status,
-    util::get_type_name,
+    core::{
+        crypto::{hash_blob, hash_buffer},
+        model::{
+            deserialize_pod, deserialize_pod_job, serialize_hashmap, serialize_hashmap_option,
+            serialize_pod, serialize_pod_job, to_yaml,
+        },
+    },
+    uniffi::{error::Result, orchestrator::Status},
 };
-use heck::ToSnakeCase as _;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_yaml;
-use std::{
-    collections::{BTreeMap, HashMap},
-    path::PathBuf,
-    result,
-};
-/// Converts a model instance into a consistent yaml.
-///
-/// # Errors
-///
-/// Will return `Err` if there is an issue converting an `instance` into YAML (w/o annotation).
-pub fn to_yaml<T: Serialize>(instance: &T) -> Result<String> {
-    let mut yaml = serde_yaml::to_string(instance)?;
-    yaml.insert_str(
-        0,
-        &format!("class: {}\n", get_type_name::<T>().to_snake_case()),
-    ); // replace class at top
-
-    Ok(yaml)
-}
-
-fn serialize_hashmap<S, K: Ord + Serialize, V: Serialize>(
-    map: &HashMap<K, V>,
-    serializer: S,
-) -> result::Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let sorted = map.iter().collect::<BTreeMap<_, _>>();
-    sorted.serialize(serializer)
-}
-
-#[expect(clippy::ref_option, reason = "Serde requires this signature.")]
-fn serialize_hashmap_option<S, K: Ord + Serialize, V: Serialize>(
-    map_option: &Option<HashMap<K, V>>,
-    serializer: S,
-) -> result::Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let sorted = map_option
-        .as_ref()
-        .map(|map| map.iter().collect::<BTreeMap<_, _>>());
-    sorted.serialize(serializer)
-}
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, path::PathBuf};
 
 // --- core model structs ---
 
@@ -72,12 +31,17 @@ pub struct Pod {
     pub input_stream: HashMap<String, StreamInfo>,
     /// Exposed, internal output directory.
     pub output_dir: PathBuf,
+    /// Exposed, internal output streams.
     #[serde(serialize_with = "serialize_hashmap")]
-    output_stream: HashMap<String, StreamInfo>,
-    source_commit_url: String,
-    recommended_cpus: f32,
-    recommended_memory: u64,
-    required_gpu: Option<GPURequirement>,
+    pub output_stream: HashMap<String, StreamInfo>,
+    /// Link to source associated with image binary.
+    pub source_commit_url: String,
+    /// Recommendation for CPU in fractional cores.
+    pub recommended_cpus: f32,
+    /// Recommendation for memory in bytes.
+    pub recommended_memory: u64,
+    /// If applicable, recommendation for GPU configuration.
+    pub required_gpu: Option<GPURequirement>,
 }
 
 impl Pod {
@@ -116,23 +80,6 @@ impl Pod {
             ..pod_no_hash
         })
     }
-}
-
-fn serialize_pod<S>(pod: &Pod, serializer: S) -> result::Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(&pod.hash)
-}
-
-fn deserialize_pod<'de, D>(deserializer: D) -> result::Result<Pod, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Ok(Pod {
-        hash: String::deserialize(deserializer)?,
-        ..Pod::default()
-    })
 }
 
 /// A compute job that specifies resource requests and input/output targets.
@@ -210,23 +157,6 @@ impl PodJob {
             ..pod_job_no_hash
         })
     }
-}
-
-fn serialize_pod_job<S>(pod_job: &PodJob, serializer: S) -> result::Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(&pod_job.hash)
-}
-
-fn deserialize_pod_job<'de, D>(deserializer: D) -> result::Result<PodJob, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Ok(PodJob {
-        hash: String::deserialize(deserializer)?,
-        ..PodJob::default()
-    })
 }
 
 /// Result from a compute job run.

--- a/src/uniffi/orchestrator/docker.rs
+++ b/src/uniffi/orchestrator/docker.rs
@@ -1,0 +1,227 @@
+use crate::{
+    core::{error::Kind, orchestrator::docker::RE_IMAGE_TAG, util::get},
+    uniffi::{
+        error::{OrcaError, Result},
+        model::{Pod, PodJob, PodResult},
+        orchestrator::{ImageKind, Orchestrator, PodRun, RunInfo},
+    },
+};
+use bollard::{
+    Docker,
+    container::{RemoveContainerOptions, StartContainerOptions, WaitContainerOptions},
+    image::{CreateImageOptions, ImportImageOptions},
+};
+use futures_util::stream::{StreamExt as _, TryStreamExt as _};
+use std::{collections::HashMap, path::PathBuf};
+use tokio::{fs::File, runtime::Runtime};
+use tokio_util::{
+    bytes::{Bytes, BytesMut},
+    codec::{BytesCodec, FramedRead},
+};
+
+/// Support for an orchestration engine using a local docker installation.
+#[derive(Debug)]
+pub struct LocalDockerOrchestrator {
+    /// API to interact with Docker daemon.
+    pub api: Docker,
+    async_driver: Runtime,
+}
+
+impl Orchestrator for LocalDockerOrchestrator {
+    fn start_with_altimage_blocking(
+        &self,
+        namespace_lookup: &HashMap<String, PathBuf>,
+        pod_job: &PodJob,
+        image: &ImageKind,
+    ) -> Result<PodRun> {
+        self.async_driver
+            .block_on(self.start_with_altimage(namespace_lookup, pod_job, image))
+    }
+    fn start_blocking(
+        &self,
+        namespace_lookup: &HashMap<String, PathBuf>,
+        pod_job: &PodJob,
+    ) -> Result<PodRun> {
+        self.async_driver
+            .block_on(self.start(namespace_lookup, pod_job))
+    }
+    fn list_blocking(&self) -> Result<Vec<PodRun>> {
+        self.async_driver.block_on(self.list())
+    }
+    fn delete_blocking(&self, pod_run: &PodRun) -> Result<()> {
+        self.async_driver.block_on(self.delete(pod_run))
+    }
+    fn get_info_blocking(&self, pod_run: &PodRun) -> Result<RunInfo> {
+        self.async_driver.block_on(self.get_info(pod_run))
+    }
+    fn get_result_blocking(&self, pod_run: &PodRun) -> Result<PodResult> {
+        self.async_driver.block_on(self.get_result(pod_run))
+    }
+    #[expect(
+        clippy::try_err,
+        reason = r#"
+        - `map_err` workaround needed since `import_image_stream` requires resolved bytes
+        - Raising an error manually on occurrence to halt so we don't just ignore
+        - Should not get as far as `Ok(_)`
+        "#
+    )]
+    async fn start_with_altimage(
+        &self,
+        namespace_lookup: &HashMap<String, PathBuf>,
+        pod_job: &PodJob,
+        image: &ImageKind,
+    ) -> Result<PodRun> {
+        let (assigned_name, container_options, container_config) = match image {
+            ImageKind::Published(remote_image) => Self::prepare_container_start_inputs(
+                namespace_lookup,
+                pod_job,
+                remote_image.clone(),
+            )?,
+            ImageKind::Tarball(image_info) => {
+                let location = namespace_lookup[&image_info.namespace].join(&image_info.path);
+                let byte_stream = FramedRead::new(File::open(&location).await?, BytesCodec::new())
+                    .map_err(|err| -> Result<BytesMut> {
+                        let resolved_error = Err::<BytesMut, OrcaError>(err.into())?;
+                        Ok(resolved_error)
+                    })
+                    .map(|result| result.ok().map_or(Bytes::new(), BytesMut::freeze));
+                let mut stream =
+                    self.api
+                        .import_image_stream(ImportImageOptions::default(), byte_stream, None);
+                let mut local_image = String::new();
+                while let Some(response) = stream.next().await {
+                    local_image = RE_IMAGE_TAG
+                        .captures_iter(&response?.stream.ok_or(OrcaError::from(
+                            Kind::EmptyResponseWhenLoadingContainerAltImage {
+                                path: location.clone(),
+                            },
+                        ))?)
+                        .find_map(|x| x.name("image").map(|name| name.as_str().to_owned()))
+                        .ok_or(OrcaError::from(Kind::NoTagFoundInContainerAltImage {
+                            path: location.clone(),
+                        }))?;
+                }
+                Self::prepare_container_start_inputs(
+                    namespace_lookup,
+                    pod_job,
+                    local_image.clone(),
+                )?
+            }
+        };
+        self.api
+            .create_container(container_options, container_config)
+            .await?;
+        self.api
+            .start_container(&assigned_name, None::<StartContainerOptions<String>>)
+            .await?;
+        Ok(PodRun::new::<Self>(pod_job, assigned_name))
+    }
+    async fn start(
+        &self,
+        namespace_lookup: &HashMap<String, PathBuf>,
+        pod_job: &PodJob,
+    ) -> Result<PodRun> {
+        let image_options = Some(CreateImageOptions {
+            from_image: pod_job.pod.image.clone(),
+            ..Default::default()
+        });
+        self.api
+            .create_image(image_options, None, None)
+            .try_collect::<Vec<_>>()
+            .await?;
+        self.start_with_altimage(
+            namespace_lookup,
+            pod_job,
+            &ImageKind::Published(pod_job.pod.image.clone()),
+        )
+        .await
+    }
+    async fn list(&self) -> Result<Vec<PodRun>> {
+        self.list_containers(HashMap::from([(
+            "label".to_owned(),
+            vec!["org.orcapod=true".to_owned()],
+        )]))
+        .await?
+        .map(|(assigned_name, run_info)| {
+            let mut pod: Pod = serde_json::from_str(get(&run_info.labels, "org.orcapod.pod")?)?;
+            pod.annotation =
+                serde_json::from_str(get(&run_info.labels, "org.orcapod.pod.annotation")?)?;
+            pod.hash
+                .clone_from(get(&run_info.labels, "org.orcapod.pod.hash")?);
+            let mut pod_job: PodJob =
+                serde_json::from_str(get(&run_info.labels, "org.orcapod.pod_job")?)?;
+            pod_job.annotation =
+                serde_json::from_str(get(&run_info.labels, "org.orcapod.pod_job.annotation")?)?;
+            pod_job
+                .hash
+                .clone_from(get(&run_info.labels, "org.orcapod.pod_job.hash")?);
+            pod_job.pod = pod;
+            Ok(PodRun::new::<Self>(&pod_job, assigned_name))
+        })
+        .collect()
+    }
+    async fn delete(&self, pod_run: &PodRun) -> Result<()> {
+        self.api
+            .remove_container(
+                &pod_run.assigned_name,
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await?;
+        Ok(())
+    }
+    async fn get_info(&self, pod_run: &PodRun) -> Result<RunInfo> {
+        let labels = vec![
+            "org.orcapod=true".to_owned(),
+            format!(
+                "org.orcapod.pod_job.annotation={}",
+                serde_json::to_string(&pod_run.pod_job.annotation)?
+            ),
+            format!("org.orcapod.pod_job.hash={}", pod_run.pod_job.hash),
+        ];
+        let (_, run_info) = self
+            .list_containers(HashMap::from([("label".to_owned(), labels)]))
+            .await?
+            .next()
+            .ok_or(OrcaError::from(Kind::NoMatchingPodRun {
+                pod_job_hash: pod_run.pod_job.hash.clone(),
+            }))?;
+        Ok(run_info)
+    }
+    async fn get_result(&self, pod_run: &PodRun) -> Result<PodResult> {
+        self.api
+            .wait_container(&pod_run.assigned_name, None::<WaitContainerOptions<String>>)
+            .try_collect::<Vec<_>>()
+            .await?;
+        let result_info = self.get_info(pod_run).await?;
+        PodResult::new(
+            None,
+            pod_run.pod_job.clone(),
+            pod_run.assigned_name.clone(),
+            result_info.status,
+            result_info.created,
+            result_info.terminated.ok_or(OrcaError::from(
+                Kind::InvalidPodResultTerminatedDatetime {
+                    pod_job_hash: pod_run.pod_job.hash.clone(),
+                },
+            ))?,
+        )
+    }
+}
+
+impl LocalDockerOrchestrator {
+    /// How to create a local docker orchestrator with an absolute path on docker host where binds
+    /// will be mounted from.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there is an issue creating a local docker orchestrator.
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            api: Docker::connect_with_local_defaults()?,
+            async_driver: Runtime::new()?,
+        })
+    }
+}

--- a/src/uniffi/orchestrator/docker.rs
+++ b/src/uniffi/orchestrator/docker.rs
@@ -1,7 +1,7 @@
 use crate::{
-    core::{error::Kind, orchestrator::docker::RE_IMAGE_TAG, util::get},
+    core::{orchestrator::docker::RE_IMAGE_TAG, util::get},
     uniffi::{
-        error::{OrcaError, Result},
+        error::{Kind, OrcaError, Result},
         model::{Pod, PodJob, PodResult},
         orchestrator::{ImageKind, Orchestrator, PodRun, RunInfo},
     },

--- a/src/uniffi/orchestrator/mod.rs
+++ b/src/uniffi/orchestrator/mod.rs
@@ -1,7 +1,6 @@
-use crate::{
+use crate::uniffi::{
     error::Result,
     model::{OrcaPath, PodJob, PodResult},
-    util::get_type_name,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, future::Future, path::PathBuf};
@@ -56,16 +55,6 @@ pub struct PodRun {
     pub orchestrator_source: String,
     /// Name given by orchestrator.
     pub assigned_name: String,
-}
-
-impl PodRun {
-    fn new<O: Orchestrator>(pod_job: &PodJob, assigned_name: String) -> Self {
-        Self {
-            pod_job: pod_job.clone(),
-            orchestrator_source: get_type_name::<O>(),
-            assigned_name,
-        }
-    }
 }
 
 /// API for standard behavior of any container orchestration engine supported.

--- a/src/uniffi/store/filestore.rs
+++ b/src/uniffi/store/filestore.rs
@@ -11,7 +11,7 @@ use std::{
 #[derive(Debug)]
 pub struct LocalFileStore {
     /// A local path to a directory where store will be located.
-    directory: PathBuf,
+    pub directory: PathBuf,
 }
 
 impl Store for LocalFileStore {
@@ -75,10 +75,6 @@ impl Store for LocalFileStore {
 }
 
 impl LocalFileStore {
-    /// Get the directory where store is located.
-    pub fn get_directory(&self) -> &Path {
-        &self.directory
-    }
     /// Construct a local file store instance in a specific directory.
     pub fn new(directory: impl AsRef<Path>) -> Self {
         Self {

--- a/src/uniffi/store/filestore.rs
+++ b/src/uniffi/store/filestore.rs
@@ -1,0 +1,88 @@
+use crate::uniffi::{
+    error::Result,
+    model::{Pod, PodJob, PodResult},
+    store::{ModelID, ModelInfo, Store},
+};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+/// Support for a storage backend on a local filesystem directory.
+#[derive(Debug)]
+pub struct LocalFileStore {
+    /// A local path to a directory where store will be located.
+    directory: PathBuf,
+}
+
+impl Store for LocalFileStore {
+    fn save_pod(&self, pod: &Pod) -> Result<()> {
+        self.save_model(pod, &pod.hash, pod.annotation.as_ref())
+    }
+    fn load_pod(&self, model_id: &ModelID) -> Result<Pod> {
+        let (mut pod, annotation, hash) = self.load_model::<Pod>(model_id)?;
+        pod.annotation = annotation;
+        pod.hash = hash;
+        Ok(pod)
+    }
+    fn list_pod(&self) -> Result<Vec<ModelInfo>> {
+        self.list_model::<Pod>()
+    }
+    fn delete_pod(&self, model_id: &ModelID) -> Result<()> {
+        self.delete_model::<Pod>(model_id)
+    }
+    fn save_pod_job(&self, pod_job: &PodJob) -> Result<()> {
+        self.save_pod(&pod_job.pod)?;
+        self.save_model(pod_job, &pod_job.hash, pod_job.annotation.as_ref())
+    }
+    fn load_pod_job(&self, model_id: &ModelID) -> Result<PodJob> {
+        let (mut pod_job, annotation, hash) = self.load_model::<PodJob>(model_id)?;
+        pod_job.annotation = annotation;
+        pod_job.hash = hash;
+        pod_job.pod = self.load_pod(&ModelID::Hash(pod_job.pod.hash))?;
+        Ok(pod_job)
+    }
+    fn list_pod_job(&self) -> Result<Vec<ModelInfo>> {
+        self.list_model::<PodJob>()
+    }
+    fn delete_pod_job(&self, model_id: &ModelID) -> Result<()> {
+        self.delete_model::<PodJob>(model_id)
+    }
+    fn save_pod_result(&self, pod_result: &PodResult) -> Result<()> {
+        self.save_pod_job(&pod_result.pod_job)?;
+        self.save_model(pod_result, &pod_result.hash, pod_result.annotation.as_ref())
+    }
+    fn load_pod_result(&self, model_id: &ModelID) -> Result<PodResult> {
+        let (mut pod_result, annotation, hash) = self.load_model::<PodResult>(model_id)?;
+        pod_result.annotation = annotation;
+        pod_result.hash = hash;
+        pod_result.pod_job = self.load_pod_job(&ModelID::Hash(pod_result.pod_job.hash))?;
+        Ok(pod_result)
+    }
+    fn list_pod_result(&self) -> Result<Vec<ModelInfo>> {
+        self.list_model::<PodResult>()
+    }
+    fn delete_pod_result(&self, model_id: &ModelID) -> Result<()> {
+        self.delete_model::<PodResult>(model_id)
+    }
+    fn delete_annotation<T>(&self, name: &str, version: &str) -> Result<()> {
+        let hash = self.lookup_hash::<T>(name, version)?;
+        let annotation_file =
+            self.make_path::<T>(&hash, Self::make_annotation_relpath(name, version));
+        fs::remove_file(&annotation_file)?;
+
+        Ok(())
+    }
+}
+
+impl LocalFileStore {
+    /// Get the directory where store is located.
+    pub fn get_directory(&self) -> &Path {
+        &self.directory
+    }
+    /// Construct a local file store instance in a specific directory.
+    pub fn new(directory: impl AsRef<Path>) -> Self {
+        Self {
+            directory: directory.as_ref().into(),
+        }
+    }
+}

--- a/src/uniffi/store/mod.rs
+++ b/src/uniffi/store/mod.rs
@@ -1,8 +1,7 @@
-use crate::{
+use crate::uniffi::{
     error::Result,
     model::{Pod, PodJob, PodResult},
 };
-
 /// Options for identifying a model.
 #[derive(Debug, Clone)]
 pub enum ModelID {

--- a/tests/crypto.rs
+++ b/tests/crypto.rs
@@ -1,8 +1,8 @@
 #![expect(missing_docs, clippy::panic_in_result_fn, reason = "OK in tests.")]
 
 use orcapod::{
-    crypto::{hash_buffer, hash_dir, hash_file},
-    error::Result,
+    core::crypto::{hash_buffer, hash_dir, hash_file},
+    uniffi::error::Result,
 };
 use std::fs::read;
 

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -8,7 +8,7 @@
 )]
 
 use names::{Generator, Name};
-use orcapod::{
+use orcapod::uniffi::{
     error::Result,
     model::{Annotation, Blob, BlobKind, Input, OrcaPath, Pod, PodJob, PodResult, StreamInfo},
     orchestrator::Status,

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -3,7 +3,7 @@
 pub mod fixture;
 use fixture::{NAMESPACE_LOOKUP_READ_ONLY, pod_job_style, pod_result_style, pod_style};
 use indoc::indoc;
-use orcapod::{error::Result, model::to_yaml};
+use orcapod::{core::model::to_yaml, uniffi::error::Result};
 
 #[test]
 fn hash_pod() -> Result<()> {

--- a/tests/orchestrator.rs
+++ b/tests/orchestrator.rs
@@ -7,7 +7,7 @@
 
 pub mod fixture;
 use fixture::{TestContainerImage, TestDirs, container_image_style, pod_job_style};
-use orcapod::{
+use orcapod::uniffi::{
     error::Result,
     model::OrcaPath,
     orchestrator::{ImageKind, Orchestrator as _, PodRun, Status, docker::LocalDockerOrchestrator},

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -11,10 +11,12 @@ use fixture::{
     NAMESPACE_LOOKUP_READ_ONLY, TestDirs, TestSetup, pod_job_style, pod_result_style, pod_style,
 };
 use orcapod::{
-    crypto::hash_buffer,
-    error::Result,
-    model::{Annotation, Pod, to_yaml},
-    store::{ModelID, ModelInfo, Store as _, filestore::LocalFileStore},
+    core::{crypto::hash_buffer, model::to_yaml},
+    uniffi::{
+        error::Result,
+        model::{Annotation, Pod},
+        store::{ModelID, ModelInfo, Store as _, filestore::LocalFileStore},
+    },
 };
 use std::{collections::HashMap, fmt::Debug, path::Path};
 


### PR DESCRIPTION
Depends on #68

We discussed a need for a reorg and the goals of such a reorg.

The following is a summary:

## Motivation

Research showed that we can introduce a Python API based on C libs that are compiled and facilitated by the [UniFFI](https://mozilla.github.io/uniffi-rs/latest/) Rust package. Thinking ahead, UniFFI brings many great benefits in automation, exposing an interoperable client, and writing code that respects DRY principles with less boilerplate.

## Restrictions to Consider

However, there are several design implications to be aware of. For instance, it was found during validation that anything exposed over the CFFI boundary with UniFFI needs to respect several [rules](https://mozilla.github.io/uniffi-rs/latest/types/namespace.html) (not exhaustive but relevant to us):
  1. No use of Rust generics
  1. No use of `const` values in traits
  1. Primitives must be owned by the client e.g. `String`, `u8`, `bool`, `f32`, etc.
  1. `BtreeMap` isn't supported but `HashMap` is.
  1. `async` functions must use the custom derive attribute from the [async-trait](https://crates.io/crates/async-trait) crate
  1. Custom types that are to be owned by client:
     1. are passed by value i.e. as a move
     1. cannot export any methods associated with them i.e. can't be invoked on client side
  1. Custom types that are to be owned by Rust:
     1. are passed by reference using `Arc<T>`
     1. can have methods exported i.e. can be invoked on client side
     1. require exporting constructor methods
     1. require exporting getter methods (e.g. for each field on a struct) since the underlying values are owned by Rust

## Limit Restrictions and Facilitate Maintenance

Given that there are a number of rules, the reorg's purpose is to confine them to be applicable only to a subset of the source. Confining them to a subset means it is easier to explain this (and write documentaton) for maintainers/contributors and grants us free reign of Rust's complete feature set in finding solutions outside of the `uniffi` context.

We decided to go with 2 top-level modules for the source: `core` and `uniffi`.

As a side-effect of splitting things in this way, it means some features may need to be applied on both sides to be complete (or just entirely in `uniffi`). For example in `LocalFileStore`, there is some pure Rust in `core` and some that is exposed over `uniffi`. As a general practice, we could always just instruct contributors to target `core` if they aren't comfortable working with UniFFI and treat the task of exposing it to `uniffi` separately; either by us or someone else.

## Visibility

Also, I've done my best in keeping the contents of `core` private since `uniffi` **is** the exposed client for Rust, Python, and anything in the future. However, there were some methods that we made public that we did not intend to expose over `uniffi` e.g. `to_yaml` which is a generic and used in tests. To minimize the noise, I reorg'ed them as-is but we could always change that later e.g. gate-keep them behind a `feature` flag that can be enabled during test runs. Since this update will be chaotic enough, this reorg PR is meant to **only** apply the reorg and not introduce any other change or functionality†.

## Footnote

† = The only exception to this was the last [commit](https://github.com/walkerlab/orcapod/pull/69/commits/b729838c21c0d5bfaf28623d05711ed3cb1addd0). The tests broke due to a new clippy lint added in a new version of Rust that had a bug in it. That commit bumped the Rust version and removed the manual getter method to avoid the bug since future PR's already had plans to remove it (see point `1. ii.` in description of #71).