### PR TITLE
Configure coverage reports

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -6,3 +6,4 @@ coverage:
       default:
         target: 100%
         threshold: 0%
+        informational: true

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -26,7 +26,7 @@ coverage:
     #     if_ci_failed: error #success, failure, error, ignore
     #     informational: false
     #     only_pulls: false
-comment: false
+# comment: false
 # comment:                  #this is a top-level key
 #   layout: " diff, flags, files"
 #   behavior: default

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -36,5 +36,5 @@ coverage:
 #   hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]]
 parsers:
   cobertura:
-    partials_as_hits: false
-    handle_missing_conditions: false
+    partials_as_hits: true
+    handle_missing_conditions: true

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -34,3 +34,7 @@ coverage:
 #   require_base: false        # [true :: must have a base report to post]
 #   require_head: true       # [true :: must have a head report to post]
 #   hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]]
+parsers:
+  cobertura:
+    partials_as_hits: false
+    handle_missing_conditions: false

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -37,4 +37,4 @@ coverage:
 parsers:
   cobertura:
     partials_as_hits: true
-    handle_missing_conditions: true
+    # handle_missing_conditions: true

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,36 @@
+# https://docs.codecov.com/docs/codecovyml-reference
+# curl -X POST --data-binary @.codecov.yaml https://codecov.io/validate
+coverage:
+  status:
+    patch: true
+    # project:
+    #   default:
+    #     target: 85.28%
+    #     threshold: 0%
+    # project:
+    #   default:   # default is the status check's name, not default settings
+    #     target: auto 
+    #     threshold: 5
+    #     base: auto 
+    #     # flags: 
+    #     #   - unit
+    #     paths: 
+    #       - "src"
+    #    # advanced settings
+    #     branches: 
+    #       - dev
+    #       - main
+    #       - uniffi-client
+    #       - guzman-raphael:uniffi-client
+    #       - guzman-raphael/orcapod:uniffi-client
+    #     if_ci_failed: error #success, failure, error, ignore
+    #     informational: false
+    #     only_pulls: false
+comment: false
+# comment:                  #this is a top-level key
+#   layout: " diff, flags, files"
+#   behavior: default
+#   require_changes: false  # if true: only post the comment if coverage changes
+#   require_base: false        # [true :: must have a base report to post]
+#   require_head: true       # [true :: must have a head report to post]
+#   hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]]

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -36,5 +36,5 @@ coverage:
 #   hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]]
 parsers:
   cobertura:
-    partials_as_hits: true
+    partials_as_hits: false
     # handle_missing_conditions: true

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -2,7 +2,10 @@
 # curl -X POST --data-binary @.codecov.yaml https://codecov.io/validate
 coverage:
   status:
-    patch: true
+    patch:
+      default:
+        target: 100%
+        threshold: 0%
     # project:
     #   default:
     #     target: 85.28%
@@ -34,7 +37,7 @@ coverage:
 #   require_base: false        # [true :: must have a base report to post]
 #   require_head: true       # [true :: must have a head report to post]
 #   hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]]
-parsers:
-  cobertura:
-    partials_as_hits: false
+# parsers:
+#   cobertura:
+#     partials_as_hits: false
     # handle_missing_conditions: true

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -6,38 +6,3 @@ coverage:
       default:
         target: 100%
         threshold: 0%
-    # project:
-    #   default:
-    #     target: 85.28%
-    #     threshold: 0%
-    # project:
-    #   default:   # default is the status check's name, not default settings
-    #     target: auto 
-    #     threshold: 5
-    #     base: auto 
-    #     # flags: 
-    #     #   - unit
-    #     paths: 
-    #       - "src"
-    #    # advanced settings
-    #     branches: 
-    #       - dev
-    #       - main
-    #       - uniffi-client
-    #       - guzman-raphael:uniffi-client
-    #       - guzman-raphael/orcapod:uniffi-client
-    #     if_ci_failed: error #success, failure, error, ignore
-    #     informational: false
-    #     only_pulls: false
-# comment: false
-# comment:                  #this is a top-level key
-#   layout: " diff, flags, files"
-#   behavior: default
-#   require_changes: false  # if true: only post the comment if coverage changes
-#   require_base: false        # [true :: must have a base report to post]
-#   require_head: true       # [true :: must have a head report to post]
-#   hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]]
-# parsers:
-#   cobertura:
-#     partials_as_hits: false
-    # handle_missing_conditions: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,12 @@ jobs:
           RUST_BACKTRACE: full
         run: |
           mkdir -p tests/.tmp
-          cargo llvm-cov --codecov --output-path target/llvm-cov-target/codecov.json -- --nocapture
+          cargo llvm-cov \
+            --ignore-filename-regex "bin/.*|lib\.rs" \
+            --codecov \
+            --output-path target/llvm-cov-target/codecov.json \
+            -- \
+              --nocapture
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,13 +26,13 @@ jobs:
           mkdir -p tests/.tmp
           cargo llvm-cov \
             --ignore-filename-regex "bin/.*|lib\.rs" \
-            --codecov \
-            --output-path target/llvm-cov-target/codecov.json \
+            --cobertura \
+            --output-path target/llvm-cov-target/cobertura.xml \
             -- \
               --nocapture
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
-          files: target/llvm-cov-target/codecov.json
+          files: target/llvm-cov-target/cobertura.xml
           verbose: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![orcapod API docs](https://img.shields.io/website?url=https://walkerlab.github.io/orcapod/&label=docs)
 ](https://walkerlab.github.io/orcapod/)
+[![codecov](https://codecov.io/github/walkerlab/orcapod/graph/badge.svg)](https://codecov.io/github/walkerlab/orcapod)
 
 # orcapod
 
@@ -9,12 +10,12 @@
 
 ```bash
 #!/bin/bash
-set -e  # stop early on non-zero exit
+set -e  # fail early on non-zero exit
 cargo clippy --all-targets -- -D warnings  # syntax and style tests
 cargo fmt --check  # formatting test
-cargo llvm-cov -- --nocapture  # integration tests w/ stdout coverage summary
-cargo llvm-cov --html -- --nocapture  # integration tests w/ HTML coverage report (target/llvm-cov/html/index.html)
-cargo llvm-cov --codecov --output-path target/llvm-cov-target/codecov.json -- --nocapture # integration tests w/ coverage report prepared for codecov
+cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" -- --nocapture  # integration tests w/ stdout coverage summary
+cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" --html -- --nocapture  # integration tests w/ HTML coverage report (target/llvm-cov/html/index.html)
+cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" --codecov --output-path target/llvm-cov-target/codecov.json -- --nocapture # integration tests w/ coverage report prepared for codecov
 ```
 
 ## Docs

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ cargo clippy --all-targets -- -D warnings  # syntax and style tests
 cargo fmt --check  # formatting test
 cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" -- --nocapture  # integration tests w/ stdout coverage summary
 cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" --html -- --nocapture  # integration tests w/ HTML coverage report (target/llvm-cov/html/index.html)
-cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" --codecov --output-path target/llvm-cov-target/codecov.json -- --nocapture # integration tests w/ coverage report prepared for codecov
+cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" --codecov --output-path target/llvm-cov-target/codecov.json -- --nocapture  # integration tests w/ codecov coverage report
+cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" --cobertura --output-path target/llvm-cov-target/cobertura.xml -- --nocapture  # integration tests w/ cobertura coverage report
 ```
 
 ## Docs

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -3,9 +3,12 @@
 pub mod fixture;
 use fixture::{NAMESPACE_LOOKUP_READ_ONLY, pod_job_style};
 use glob::glob;
-use orcapod::uniffi::{
-    error::{OrcaError, Result},
-    orchestrator::{Orchestrator as _, docker::LocalDockerOrchestrator},
+use orcapod::{
+    core::crypto::hash_file,
+    uniffi::{
+        error::{OrcaError, Result},
+        orchestrator::{Orchestrator as _, docker::LocalDockerOrchestrator},
+    },
 };
 use serde_json;
 use serde_yaml;
@@ -67,5 +70,21 @@ fn external_yaml() {
     assert!(
         serde_yaml::from_str::<HashMap<String, String>>(":").is_err_and(contains_debug),
         "Did not raise a serde yaml error."
+    );
+}
+
+#[test]
+fn internal_invalid_filepath() {
+    assert!(
+        hash_file("nonexistent_file.txt").is_err_and(contains_debug),
+        "Did not raise an invalid filepath error."
+    );
+}
+
+#[test]
+fn internal_key_missing() {
+    assert!(
+        pod_job_style(&HashMap::new()).is_err_and(contains_debug),
+        "Did not raise a key missing error."
     );
 }

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,4 +1,4 @@
-#![expect(missing_docs, clippy::expect_used, reason = "OK in tests.")]
+#![expect(missing_docs, clippy::panic_in_result_fn, reason = "OK in tests.")]
 
 pub mod fixture;
 use fixture::{NAMESPACE_LOOKUP_READ_ONLY, pod_job_style};
@@ -9,11 +9,10 @@ use orcapod::uniffi::{
 };
 use serde_json;
 use serde_yaml;
-use std::{collections::HashMap, fmt, fs, path::PathBuf, result};
+use std::{collections::HashMap, fs, path::PathBuf};
 
-fn check<A: fmt::Debug, B: Into<OrcaError>>(value: result::Result<A, B>) -> String {
-    let error: OrcaError = value.expect_err("Did not return an expected error.").into();
-    format!("{error:?}")
+fn contains_debug(error: impl Into<OrcaError>) -> bool {
+    !format!("{:?}", error.into()).is_empty()
 }
 
 #[test]
@@ -21,31 +20,52 @@ fn external_bollard() -> Result<()> {
     let orch = LocalDockerOrchestrator::new()?;
     let mut pod_job = pod_job_style(&NAMESPACE_LOOKUP_READ_ONLY)?;
     pod_job.pod.image = "nonexistent_image".to_owned();
-    check(orch.start_blocking(&NAMESPACE_LOOKUP_READ_ONLY, &pod_job));
+    assert!(
+        orch.start_blocking(&NAMESPACE_LOOKUP_READ_ONLY, &pod_job)
+            .is_err_and(contains_debug),
+        "Did not raise a bollard error."
+    );
     Ok(())
 }
 
 #[test]
 fn external_glob() {
-    check(glob("a**/b"));
+    assert!(
+        glob("a**/b").is_err_and(contains_debug),
+        "Did not raise a glob error."
+    );
 }
 
 #[test]
 fn external_io() {
-    check(fs::read_to_string("nonexistent_file.txt"));
+    assert!(
+        fs::read_to_string("nonexistent_file.txt").is_err_and(contains_debug),
+        "Did not raise an I/O error."
+    );
 }
 
 #[test]
 fn external_path_prefix() {
-    check(PathBuf::from("/fake/path").strip_prefix("/missing/path"));
+    assert!(
+        PathBuf::from("/fake/path")
+            .strip_prefix("/missing/path")
+            .is_err_and(contains_debug),
+        "Did not raise a path prefix error."
+    );
 }
 
 #[test]
 fn external_json() {
-    check(serde_json::from_str::<HashMap<String, String>>("{"));
+    assert!(
+        serde_json::from_str::<HashMap<String, String>>("{").is_err_and(contains_debug),
+        "Did not raise a serde json error."
+    );
 }
 
 #[test]
 fn external_yaml() {
-    check(serde_yaml::from_str::<HashMap<String, String>>(":"));
+    assert!(
+        serde_yaml::from_str::<HashMap<String, String>>(":").is_err_and(contains_debug),
+        "Did not raise a serde yaml error."
+    );
 }

--- a/tests/orchestrator.rs
+++ b/tests/orchestrator.rs
@@ -1,9 +1,4 @@
-#![expect(
-    clippy::expect_used,
-    missing_docs,
-    clippy::panic_in_result_fn,
-    reason = "OK in tests."
-)]
+#![expect(missing_docs, clippy::panic_in_result_fn, reason = "OK in tests.")]
 
 pub mod fixture;
 use fixture::{TestContainerImage, TestDirs, container_image_style, pod_job_style};
@@ -75,9 +70,8 @@ where
     assert!(
         orchestrator
             .get_info_blocking(&pod_run)
-            .expect_err("Unexpectedly succeeded.")
-            .is_purged_pod_run(),
-        "Returned a different OrcaError than one expected when getting info of a purged pod run."
+            .is_err_and(|error| error.is_purged_pod_run() && !format!("{error:?}").is_empty()),
+        "Did not raise a purged pod run error."
     );
     Ok(())
 }

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -223,9 +223,8 @@ fn pod_annotation_delete() -> Result<()> {
     assert!(
         store
             .delete_annotation::<Pod>("style-transfer", "9.9.9")
-            .expect_err("Unexpectedly succeeded.")
-            .is_invalid_annotation(),
-        "Returned a different OrcaError than one expected when deleting an invalid annotation."
+            .is_err_and(|error| error.is_invalid_annotation() && !format!("{error:?}").is_empty()),
+        "Did not raise an invalid annotation error."
     );
     Ok(())
 }


### PR DESCRIPTION
Now that we have our code coverage integrated into the dev flow and the report published somewhere, things have improved. However, it was still missing some tweaking so that it could be the ideal setup for coverage checks.

To address that, the config here:
- Lets partial coverage count as normal coverage.
  - Apparently `llvm-cov` also supports generating [cobertura](https://cobertura.github.io/cobertura/) coverage reports which is also allowed to be uploaded to codecov.io. This kind of coverage treats partial coverage as fully covered (it might also be configurable) which better matches the reports generated from the stdout line coverage summary.
- Requires patch coverage to be 100%.
  - codecov.io apparently differentiates between [2 kinds of coverage](https://docs.codecov.com/docs/frequently-asked-questions#whats-the-difference-between-codecovproject-and-codecovpatch):
    - project coverage: overall codebase coverage and what most people normally think of
    - patch coverage: coverage of only the diff in PR's i.e. how much a contributor has changed is actually covered
  - Using the `codecov.yaml` file is how you can modify the codecov.io experience from the default. Codecov.io seems to prefer patch over project coverage and disables project coverage by default. I'd normally use project coverage but there appears to be a [bug](https://github.com/codecov/feedback/issues/689) in it currently. Therefore, I've set and modified patch coverage to achieve the same intent: new/modified code introduced should be completely covered.
- Excludes coverage for any executables (`bin/*`) and the top-level `lib.rs`
    
Also added a badge on our README to highlight our current project code coverage and updated the docs.