### PR TITLE
Add multiple serialization schemes for models

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,19 +1,3 @@
 excessive-nesting-threshold = 4
 too-many-arguments-threshold = 10
 allowed-idents-below-min-chars = ["..", "k", "v", "f", "re", "id", "Ok", "'_"]
-allowed-duplicate-crates = [
-    "bitflags",
-    "clap",
-    "clap_derive",
-    "clap_lex",
-    "getrandom",
-    "hashbrown",
-    "heck",
-    "indexmap",
-    "strsim",
-    "syn",
-    "thiserror",
-    "thiserror-impl",
-    "wasi",
-    "windows-sys",
-]

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,6 +1,6 @@
 excessive-nesting-threshold = 4
 too-many-arguments-threshold = 10
-allowed-idents-below-min-chars = ["..", "k", "f", "re", "id", "Ok", "'_"]
+allowed-idents-below-min-chars = ["..", "k", "v", "f", "re", "id", "Ok", "'_"]
 allowed-duplicate-crates = [
     "bitflags",
     "clap",

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # DevContainer image
-FROM rust:1.86-slim
+FROM rust:1.87-slim
 RUN \
     adduser --system --disabled-password --shell /bin/bash --home /home/vscode vscode && \
     # install docker

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,7 +41,7 @@ RUN \
 RUN \
     # install python manager
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    uv venv -p 3.9 ~/.local/share/base && \
+    uv venv -p 3.10 ~/.local/share/base && \
     # pip package based on C lib/client
     uv pip install cffi maturin ipykernel -p ~/.local/share/base && \
     echo '. ~/.local/share/base/bin/activate' >> ~/.bashrc

--- a/.devcontainer/gpu/Dockerfile
+++ b/.devcontainer/gpu/Dockerfile
@@ -41,7 +41,7 @@ ENV PATH=${PATH}:/root/.local/bin
 RUN \
     # install python manager
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    uv venv -p 3.9 ~/.local/share/base && \
+    uv venv -p 3.10 ~/.local/share/base && \
     # pip package based on C lib/client
     uv pip install cffi maturin ipykernel -p ~/.local/share/base && \
     echo '. ~/.local/share/base/bin/activate' >> ~/.bashrc

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,11 +21,11 @@ jobs:
           components: rustfmt,clippy
       - name: Install Rust code coverage
         uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Run syntax and style tests
+      - name: Run Rust syntax and style tests
         run: cargo clippy --all-targets -- -D warnings
-      - name: Run format test
+      - name: Run Rust format test
         run: cargo fmt --check
-      - name: Run integration tests w/ coverage report
+      - name: Run Rust integration tests w/ coverage report
         env:
           RUST_BACKTRACE: full
         run: |
@@ -36,6 +36,13 @@ jobs:
             --output-path target/llvm-cov-target/cobertura.xml \
             -- \
               --nocapture
+      - name: Run Python integration tests
+        env:
+          RUST_BACKTRACE: full
+        run: |
+          . ~/.local/share/base/bin/activate
+          maturin develop --uv
+          python tests/extra/python/smoke_test.py -- tests/.tmp
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Rust + components
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.86
+          toolchain: 1.87
           components: rustfmt,clippy
       - name: Install Rust code coverage
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Diagram
         uses: ./.github/actions/build-diagram
-  syntax-style-format-and-integration:
+  rust-syntax-style-format-and-integration:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
@@ -19,13 +19,13 @@ jobs:
         with:
           toolchain: 1.87
           components: rustfmt,clippy
-      - name: Install Rust code coverage
+      - name: Install code coverage
         uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Run Rust syntax and style tests
+      - name: Run syntax and style tests
         run: cargo clippy --all-targets -- -D warnings
-      - name: Run Rust format test
+      - name: Run format test
         run: cargo fmt --check
-      - name: Run Rust integration tests w/ coverage report
+      - name: Run integration tests w/ coverage report
         env:
           RUST_BACKTRACE: full
         run: |
@@ -36,16 +36,25 @@ jobs:
             --output-path target/llvm-cov-target/cobertura.xml \
             -- \
               --nocapture
-      - name: Run Python integration tests
-        env:
-          RUST_BACKTRACE: full
-        run: |
-          . ~/.local/share/base/bin/activate
-          maturin develop --uv
-          python tests/extra/python/smoke_test.py -- tests/.tmp
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           files: target/llvm-cov-target/cobertura.xml
           verbose: true
+  python-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python + components
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh && \
+          uv venv -p 3.10 ~/.local/share/base && \
+          uv pip install cffi maturin -p ~/.local/share/base
+      - name: Run integration tests
+        env:
+          RUST_BACKTRACE: full
+        run: |
+          . ~/.local/share/base/bin/activate
+          maturin develop --uv
+          python tests/extra/python/smoke_test.py -- tests/.tmp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ tokio = { version = "1.41.0", features = ["full"] }
 # utilities for async calls
 tokio-util = "0.7.13"
 # automated CFFI + bindings in other languages
-uniffi = { version = "0.29.1", features = ["cli"] }
+uniffi = { version = "0.29.1", features = ["cli", "tokio"] }
 
 [[bin]]
 name = "uniffi-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ missing_docs_in_private_items = { level = "allow", priority = 127 }    # missing
 missing_inline_in_public_items = { level = "allow", priority = 127 }   # let rust compiler determine best inline logic
 missing_trait_methods = { level = "allow", priority = 127 }            # allow in favor of rustc `implement the missing item`
 module_name_repetitions = { level = "allow", priority = 127 }          # allow use of module name in type names
+multiple_crate_versions = { level = "allow", priority = 127 }          # allow since list of exceptions changes frequently from external
 multiple_inherent_impl = { level = "allow", priority = 127 }           # required in best practice to limit exposure over UniFFI
 must_use_candidate = { level = "allow", priority = 127 }               # omitting #[must_use] ok
 mod_module_files = { level = "allow", priority = 127 }                 # mod directories ok

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,14 @@ getset = { version = "0.1.5", git = "https://github.com/guzman-raphael/getset.gi
 glob = "0.3.1"
 # strings to snake_case
 heck = "0.5.0"
+# hashmaps that preserve insertion order
+indexmap = { version = "2.9.0", features = ["serde"] }
 # random name generator
 names = "0.14.0"
 # complex pattern matching in strings
 regex = "1.11.0"
 # serialization/deserialization to/from filestore
-serde = { version = "1.0.210", features = ["derive"] }
+serde = { version = "1.0.210", features = ["derive", "rc"] }
 # JSON in sharing memory with local docker orchestrator
 serde_json = "1.0.137"
 # YAML in filestore

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@
 ```bash
 #!/bin/bash
 set -e  # fail early on non-zero exit
-cargo clippy --all-targets -- -D warnings  # syntax and style tests
-cargo fmt --check  # formatting test
-cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" -- --nocapture  # integration tests w/ stdout coverage summary
-cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" --html -- --nocapture  # integration tests w/ HTML coverage report (target/llvm-cov/html/index.html)
-cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" --codecov --output-path target/llvm-cov-target/codecov.json -- --nocapture  # integration tests w/ codecov coverage report
-cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" --cobertura --output-path target/llvm-cov-target/cobertura.xml -- --nocapture  # integration tests w/ cobertura coverage report
+cargo clippy --all-targets -- -D warnings  # Rust syntax and style tests
+cargo fmt --check  # Rust formatting test
+cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" -- --nocapture  # Rust integration tests w/ stdout coverage summary
+cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" --html -- --nocapture  # Rust integration tests w/ HTML coverage report (target/llvm-cov/html/index.html)
+cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" --codecov --output-path target/llvm-cov-target/codecov.json -- --nocapture  # Rust integration tests w/ codecov coverage report
+cargo llvm-cov --ignore-filename-regex "bin/.*|lib\.rs" --cobertura --output-path target/llvm-cov-target/cobertura.xml -- --nocapture  # Rust integration tests w/ cobertura coverage report
+. ~/.local/share/base/bin/activate && maturin develop --uv && RUST_BACKTRACE=1 python tests/extra/python/smoke_test.py -- tests/.tmp # Python integration tests
 ```
 
 ## Docs

--- a/cspell.json
+++ b/cspell.json
@@ -74,5 +74,12 @@
         "strsim",
         "getrandom",
         "wasi"
+    ],
+    "useGitignore": false,
+    "ignorePaths": [
+        "Cargo.lock",
+        "target",
+        "*.dot",
+        "tests/.tmp"
     ]
 }

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -6,8 +6,9 @@ use crate::{
     },
 };
 use heck::ToSnakeCase as _;
+use indexmap::IndexMap;
 use serde::{Deserialize as _, Deserializer, Serialize, Serializer};
-use serde_yaml;
+use serde_yaml::{self, Value};
 use std::{
     collections::{BTreeMap, HashMap},
     result,
@@ -19,12 +20,21 @@ use std::{
 ///
 /// Will return `Err` if there is an issue converting an `instance` into YAML (w/o annotation).
 pub fn to_yaml<T: Serialize>(instance: &T) -> Result<String> {
-    let mut yaml = serde_yaml::to_string(instance)?;
+    let mapping: IndexMap<String, Value> = serde_yaml::from_str(&serde_yaml::to_string(instance)?)?; // cast to map
+    let mut yaml = serde_yaml::to_string(
+        &mapping
+            .iter()
+            .filter_map(|(k, v)| match &**k {
+                "annotation" | "hash" => None,
+                "pod" | "pod_job" => Some((k, v["hash"].clone())),
+                _ => Some((k, v.clone())),
+            })
+            .collect::<IndexMap<_, _>>(),
+    )?; // skip fields and convert refs to hash pointers
     yaml.insert_str(
         0,
         &format!("class: {}\n", get_type_name::<T>().to_snake_case()),
     ); // replace class at top
-
     Ok(yaml)
 }
 
@@ -53,41 +63,54 @@ where
     sorted.serialize(serializer)
 }
 
-pub(crate) fn serialize_pod<S>(pod: &Pod, serializer: S) -> result::Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(&pod.hash)
-}
-
+#[expect(
+    clippy::expect_used,
+    reason = "Function signature required by serde API."
+)]
 pub(crate) fn deserialize_pod<'de, D>(deserializer: D) -> result::Result<Arc<Pod>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    Ok(Pod {
-        hash: String::deserialize(deserializer)?,
-        ..Pod::default()
-    }
-    .into())
+    let value = Value::deserialize(deserializer)?;
+    (value).as_str().map_or_else(
+        || {
+            Ok(serde_yaml::from_value(value.clone())
+                .expect("Failed to convert from serde value to specific type."))
+        },
+        |hash| {
+            Ok({
+                Pod {
+                    hash: hash.to_owned(),
+                    ..Pod::default()
+                }
+                .into()
+            })
+        },
+    )
 }
 
-pub(crate) fn serialize_pod_job<S>(
-    pod_job: &PodJob,
-    serializer: S,
-) -> result::Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(&pod_job.hash)
-}
-
+#[expect(
+    clippy::expect_used,
+    reason = "Function signature required by serde API."
+)]
 pub(crate) fn deserialize_pod_job<'de, D>(deserializer: D) -> result::Result<Arc<PodJob>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    Ok(PodJob {
-        hash: String::deserialize(deserializer)?,
-        ..PodJob::default()
-    }
-    .into())
+    let value = Value::deserialize(deserializer)?;
+    (value).as_str().map_or_else(
+        || {
+            Ok(serde_yaml::from_value(value.clone())
+                .expect("Failed to convert from serde value to specific type."))
+        },
+        |hash| {
+            Ok({
+                PodJob {
+                    hash: hash.to_owned(),
+                    ..PodJob::default()
+                }
+                .into()
+            })
+        },
+    )
 }

--- a/src/core/orchestrator/docker.rs
+++ b/src/core/orchestrator/docker.rs
@@ -125,23 +125,14 @@ impl LocalDockerOrchestrator {
         let labels = HashMap::from([
             ("org.orcapod".to_owned(), "true".to_owned()),
             (
-                "org.orcapod.pod.annotation".to_owned(),
-                serde_json::to_string(&pod_job.pod.annotation)?,
-            ),
-            ("org.orcapod.pod.hash".to_owned(), pod_job.pod.hash.clone()),
-            (
-                "org.orcapod.pod".to_owned(),
-                serde_json::to_string(&*pod_job.pod)?,
+                "org.orcapod.pod_job".to_owned(),
+                serde_json::to_string(&pod_job)?,
             ),
             (
                 "org.orcapod.pod_job.annotation".to_owned(),
                 serde_json::to_string(&pod_job.annotation)?,
             ),
             ("org.orcapod.pod_job.hash".to_owned(), pod_job.hash.clone()),
-            (
-                "org.orcapod.pod_job".to_owned(),
-                serde_json::to_string(&pod_job)?,
-            ),
         ]);
         let command = pod_job
             .pod

--- a/src/core/orchestrator/mod.rs
+++ b/src/core/orchestrator/mod.rs
@@ -5,6 +5,15 @@ use crate::{
         orchestrator::{Orchestrator, PodRun},
     },
 };
+use std::sync::LazyLock;
+use tokio::runtime::Runtime;
+
+#[expect(
+    clippy::expect_used,
+    reason = "Should be able to create Tokio runtime."
+)]
+pub static ASYNC_RUNTIME: LazyLock<Runtime> =
+    LazyLock::new(|| Runtime::new().expect("Unable to create Tokio runtime."));
 
 impl PodRun {
     pub(crate) fn new<O: Orchestrator>(pod_job: &PodJob, assigned_name: String) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,4 +26,6 @@ pub mod core;
 ///    1. require exporting constructor methods
 ///    1. require exporting getter methods (e.g. for each field on a `struct`) since the underlying
 ///       values are owned by Rust
+/// 1. No default trait implementations
+/// 1. (Rust limitation) No associated functions in traits e.g. class methods in Python
 pub mod uniffi;

--- a/src/uniffi/model.rs
+++ b/src/uniffi/model.rs
@@ -3,7 +3,7 @@ use crate::{
         crypto::{hash_blob, hash_buffer},
         model::{
             deserialize_pod, deserialize_pod_job, serialize_hashmap, serialize_hashmap_option,
-            serialize_pod, serialize_pod_job, to_yaml,
+            to_yaml,
         },
     },
     uniffi::{error::Result, orchestrator::Status},
@@ -36,10 +36,9 @@ pub enum ModelType {
 #[uniffi::export(Display)]
 pub struct Pod {
     /// Metadata that doesn't affect reproducibility.
-    #[serde(skip)]
     pub annotation: Option<Annotation>,
     /// Unique id based on reproducibility.
-    #[serde(skip)]
+    #[serde(default)]
     pub hash: String,
     /// Reproducible environment for compute.
     pub image: String,
@@ -112,13 +111,12 @@ impl Pod {
 #[uniffi::export(Display)]
 pub struct PodJob {
     /// Metadata that doesn't affect reproducibility.
-    #[serde(skip)]
     pub annotation: Option<Annotation>,
     /// Unique id based on reproducibility.
-    #[serde(skip)]
+    #[serde(default)]
     pub hash: String,
     /// A pod to base the pod job on.
-    #[serde(serialize_with = "serialize_pod", deserialize_with = "deserialize_pod")]
+    #[serde(deserialize_with = "deserialize_pod")]
     pub pod: Arc<Pod>,
     /// Attached, external input streams.
     #[serde(serialize_with = "serialize_hashmap")]
@@ -191,16 +189,12 @@ impl PodJob {
 #[derive(uniffi::Record, Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct PodResult {
     /// Metadata that doesn't affect reproducibility.
-    #[serde(skip)]
     pub annotation: Option<Annotation>,
     /// Unique id based on reproducibility.
-    #[serde(skip)]
+    #[serde(default)]
     pub hash: String,
     /// A pod job that originated the pod result.
-    #[serde(
-        serialize_with = "serialize_pod_job",
-        deserialize_with = "deserialize_pod_job"
-    )]
+    #[serde(deserialize_with = "deserialize_pod_job")]
     pub pod_job: Arc<PodJob>,
     /// Name given by orchestrator.
     pub assigned_name: String,

--- a/src/uniffi/orchestrator/docker.rs
+++ b/src/uniffi/orchestrator/docker.rs
@@ -1,5 +1,8 @@
 use crate::{
-    core::{orchestrator::docker::RE_IMAGE_TAG, util::get},
+    core::{
+        orchestrator::{ASYNC_RUNTIME, docker::RE_IMAGE_TAG},
+        util::get,
+    },
     uniffi::{
         error::{OrcaError, Result, selector},
         model::{PodJob, PodResult},
@@ -16,7 +19,7 @@ use derive_more::Display;
 use futures_util::stream::{StreamExt as _, TryStreamExt as _};
 use snafu::{OptionExt as _, futures::TryFutureExt as _};
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
-use tokio::{fs::File, runtime::Runtime};
+use tokio::fs::File;
 use tokio_util::{
     bytes::{Bytes, BytesMut},
     codec::{BytesCodec, FramedRead},
@@ -30,7 +33,6 @@ use uniffi;
 pub struct LocalDockerOrchestrator {
     /// API to interact with Docker daemon.
     pub api: Docker,
-    async_driver: Runtime,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -42,28 +44,26 @@ impl Orchestrator for LocalDockerOrchestrator {
         pod_job: &PodJob,
         image: &ImageKind,
     ) -> Result<PodRun> {
-        self.async_driver
-            .block_on(self.start_with_altimage(namespace_lookup, pod_job, image))
+        ASYNC_RUNTIME.block_on(self.start_with_altimage(namespace_lookup, pod_job, image))
     }
     fn start_blocking(
         &self,
         namespace_lookup: &HashMap<String, PathBuf>,
         pod_job: &PodJob,
     ) -> Result<PodRun> {
-        self.async_driver
-            .block_on(self.start(namespace_lookup, pod_job))
+        ASYNC_RUNTIME.block_on(self.start(namespace_lookup, pod_job))
     }
     fn list_blocking(&self) -> Result<Vec<PodRun>> {
-        self.async_driver.block_on(self.list())
+        ASYNC_RUNTIME.block_on(self.list())
     }
     fn delete_blocking(&self, pod_run: &PodRun) -> Result<()> {
-        self.async_driver.block_on(self.delete(pod_run))
+        ASYNC_RUNTIME.block_on(self.delete(pod_run))
     }
     fn get_info_blocking(&self, pod_run: &PodRun) -> Result<RunInfo> {
-        self.async_driver.block_on(self.get_info(pod_run))
+        ASYNC_RUNTIME.block_on(self.get_info(pod_run))
     }
     fn get_result_blocking(&self, pod_run: &PodRun) -> Result<PodResult> {
-        self.async_driver.block_on(self.get_result(pod_run))
+        ASYNC_RUNTIME.block_on(self.get_result(pod_run))
     }
     #[expect(
         clippy::try_err,
@@ -225,7 +225,6 @@ impl LocalDockerOrchestrator {
     pub fn new() -> Result<Self> {
         Ok(Self {
             api: Docker::connect_with_local_defaults()?,
-            async_driver: Runtime::new()?,
         })
     }
 }

--- a/src/uniffi/orchestrator/docker.rs
+++ b/src/uniffi/orchestrator/docker.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{orchestrator::docker::RE_IMAGE_TAG, util::get},
     uniffi::{
         error::{OrcaError, Result, selector},
-        model::{Pod, PodJob, PodResult},
+        model::{PodJob, PodResult},
         orchestrator::{ImageKind, Orchestrator, PodRun, RunInfo},
     },
 };
@@ -156,19 +156,8 @@ impl Orchestrator for LocalDockerOrchestrator {
         )]))
         .await?
         .map(|(assigned_name, run_info)| {
-            let mut pod: Pod = serde_json::from_str(get(&run_info.labels, "org.orcapod.pod")?)?;
-            pod.annotation =
-                serde_json::from_str(get(&run_info.labels, "org.orcapod.pod.annotation")?)?;
-            pod.hash
-                .clone_from(get(&run_info.labels, "org.orcapod.pod.hash")?);
-            let mut pod_job: PodJob =
+            let pod_job: PodJob =
                 serde_json::from_str(get(&run_info.labels, "org.orcapod.pod_job")?)?;
-            pod_job.annotation =
-                serde_json::from_str(get(&run_info.labels, "org.orcapod.pod_job.annotation")?)?;
-            pod_job
-                .hash
-                .clone_from(get(&run_info.labels, "org.orcapod.pod_job.hash")?);
-            pod_job.pod = pod.into();
             Ok(PodRun::new::<Self>(&pod_job, assigned_name))
         })
         .collect()

--- a/src/uniffi/orchestrator/docker.rs
+++ b/src/uniffi/orchestrator/docker.rs
@@ -33,7 +33,7 @@ pub struct LocalDockerOrchestrator {
     async_driver: Runtime,
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 #[async_trait::async_trait]
 impl Orchestrator for LocalDockerOrchestrator {
     fn start_with_altimage_blocking(

--- a/tests/extra/python/smoke_test.py
+++ b/tests/extra/python/smoke_test.py
@@ -6,6 +6,7 @@
 import shutil
 from pathlib import Path
 import argparse
+import asyncio
 from orcapod import (
     Pod,
     PodJob,
@@ -72,7 +73,7 @@ def start_pod_job(data, config):
 
 
 def wait_for_pod_result(data, _):
-    print([str(p) for p in data["orch"].list_blocking()])
+    print([str(p) for p in asyncio.run(data["orch"].list())])
     print("waiting to finish...")
     data["pod_result"] = data["orch"].get_result_blocking(pod_run=data["pod_run"])
     return data["pod_result"], data

--- a/tests/extra/python/smoke_test.py
+++ b/tests/extra/python/smoke_test.py
@@ -16,6 +16,7 @@ from orcapod import (
     LocalFileStore,
     ModelId,
     ModelType,
+    OrcaError,
 )
 
 
@@ -131,8 +132,9 @@ def test(test_dir, steps):
             print(f"\n==================== {step.__name__} ====================\n")
             result, data = step(data, config)
             print(result)
-    except Exception as e:
-        raise e
+    except OrcaError as e:
+        if "No such file or directory (os error 2)" not in str(e):
+            raise e
     finally:
         shutil.rmtree(test_dir)
 


### PR DESCRIPTION
- Add multiple serialization schemes for models e.g. YAML => storage optimized, JSON => memory/comm optimized
- Use global tokio runtime when calling `async` from `sync`
- Fix bug when calling async functions in Python using `asyncio`
- Improve `smoke_test.py` exit code checks
- Bump Python p39 -> py310 since debugger requires it
- Add Python integration tests to CI
- Bump Rust
- Exclude clippy checks for `multiple_crate_versions` since typically caused by external dependencies that are out of our control