### PR TITLE
Logging features for during and post run

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -91,6 +91,7 @@ impl fmt::Debug for OrcaError {
         match &self.kind {
             Kind::EmptyResponseWhenLoadingContainerAltImage { backtrace, .. }
             | Kind::GeneratedNamesOverflow { backtrace, .. }
+            | Kind::FailedToExtractRunInfo { backtrace, .. }
             | Kind::InvalidFilepath { backtrace, .. }
             | Kind::InvalidPodResultTerminatedDatetime { backtrace, .. }
             | Kind::KeyMissing { backtrace, .. }

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -25,7 +25,7 @@ pub fn to_yaml<T: Serialize>(instance: &T) -> Result<String> {
         &mapping
             .iter()
             .filter_map(|(k, v)| match &**k {
-                "annotation" | "hash" => None,
+                "annotation" | "hash" | "logs" => None,
                 "pod" | "pod_job" => Some((k, v["hash"].clone())),
                 _ => Some((k, v.clone())),
             })

--- a/src/core/orchestrator/docker.rs
+++ b/src/core/orchestrator/docker.rs
@@ -245,7 +245,7 @@ impl LocalDockerOrchestrator {
                         (ContainerStateStatusEnum::RUNNING, _) => Status::Running,
                         (ContainerStateStatusEnum::EXITED, 0) => Status::Completed,
                         (ContainerStateStatusEnum::EXITED, code) => Status::Failed(code),
-                        _ => todo!(),
+                        _ => Status::Undefined,
                     },
                     mounts: container_spec
                         .mounts

--- a/src/core/store/filestore.rs
+++ b/src/core/store/filestore.rs
@@ -110,7 +110,7 @@ impl LocalFileStore {
         Ok(model_info.hash)
     }
 
-    fn save_file(file: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Result<()> {
+    pub(crate) fn save_file(file: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Result<()> {
         if let Some(parent) = file.as_ref().parent() {
             fs::create_dir_all(parent)?;
         }

--- a/src/uniffi/error.rs
+++ b/src/uniffi/error.rs
@@ -31,6 +31,13 @@ pub(crate) enum Kind {
     },
     #[snafu(display("Out of generated random names."))]
     GeneratedNamesOverflow { backtrace: Option<Backtrace> },
+    #[snafu(display(
+        "Failed to extract run info from the container image file: {container_name}."
+    ))]
+    FailedToExtractRunInfo {
+        container_name: String,
+        backtrace: Option<Backtrace>,
+    },
     #[snafu(display("{source} ({path:?})."))]
     InvalidFilepath {
         path: PathBuf,

--- a/src/uniffi/model.rs
+++ b/src/uniffi/model.rs
@@ -204,6 +204,9 @@ pub struct PodResult {
     pub created: u64,
     /// Time in epoch when terminated in seconds.
     pub terminated: u64,
+    /// Output logs of container
+    #[serde(default)]
+    pub logs: String,
 }
 
 impl PodResult {
@@ -215,10 +218,11 @@ impl PodResult {
     pub fn new(
         annotation: Option<Annotation>,
         pod_job: Arc<PodJob>,
-        assigned_name: String,
+        assigned_name: String, // Skip
         status: Status,
-        created: u64,
-        terminated: u64,
+        created: u64,    // skip
+        terminated: u64, // skip
+        logs: String,
     ) -> Result<Self> {
         let pod_result_no_hash = Self {
             annotation,
@@ -228,7 +232,9 @@ impl PodResult {
             status,
             created,
             terminated,
+            logs,
         };
+
         Ok(Self {
             hash: hash_buffer(to_yaml(&pod_result_no_hash)?),
             ..pod_result_no_hash

--- a/src/uniffi/orchestrator/docker.rs
+++ b/src/uniffi/orchestrator/docker.rs
@@ -15,6 +15,7 @@ use bollard::{
     container::{
         LogOutput, LogsOptions, RemoveContainerOptions, StartContainerOptions, WaitContainerOptions,
     },
+    errors::Error::DockerContainerWaitError,
     image::{CreateImageOptions, ImportImageOptions},
 };
 use derive_more::Display;
@@ -197,6 +198,10 @@ impl Orchestrator for LocalDockerOrchestrator {
             })?;
         Ok(run_info)
     }
+    #[expect(
+        clippy::wildcard_enum_match_arm,
+        reason = "Favor readability due to complexity in external dependency."
+    )]
     async fn get_result(&self, pod_run: &PodRun) -> Result<PodResult> {
         match self
             .api

--- a/src/uniffi/orchestrator/docker.rs
+++ b/src/uniffi/orchestrator/docker.rs
@@ -6,20 +6,22 @@ use crate::{
     uniffi::{
         error::{OrcaError, Result, selector},
         model::{PodJob, PodResult},
-        orchestrator::{ImageKind, Orchestrator, PodRun, RunInfo},
+        orchestrator::{ImageKind, Orchestrator, PodRun, RunInfo, Status},
     },
 };
 use async_trait;
 use bollard::{
     Docker,
-    container::{RemoveContainerOptions, StartContainerOptions, WaitContainerOptions},
+    container::{
+        LogOutput, LogsOptions, RemoveContainerOptions, StartContainerOptions, WaitContainerOptions,
+    },
     image::{CreateImageOptions, ImportImageOptions},
 };
 use derive_more::Display;
 use futures_util::stream::{StreamExt as _, TryStreamExt as _};
 use snafu::{OptionExt as _, futures::TryFutureExt as _};
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
-use tokio::fs::File;
+use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+use tokio::{fs::File, time::sleep};
 use tokio_util::{
     bytes::{Bytes, BytesMut},
     codec::{BytesCodec, FramedRead},
@@ -64,6 +66,9 @@ impl Orchestrator for LocalDockerOrchestrator {
     }
     fn get_result_blocking(&self, pod_run: &PodRun) -> Result<PodResult> {
         ASYNC_RUNTIME.block_on(self.get_result(pod_run))
+    }
+    fn get_logs_blocking(&self, pod_run: &PodRun) -> Result<String> {
+        ASYNC_RUNTIME.block_on(self.get_logs(pod_run))
     }
     #[expect(
         clippy::try_err,
@@ -193,11 +198,27 @@ impl Orchestrator for LocalDockerOrchestrator {
         Ok(run_info)
     }
     async fn get_result(&self, pod_run: &PodRun) -> Result<PodResult> {
-        self.api
+        match self
+            .api
             .wait_container(&pod_run.assigned_name, None::<WaitContainerOptions<String>>)
             .try_collect::<Vec<_>>()
-            .await?;
-        let result_info = self.get_info(pod_run).await?;
+            .await
+        {
+            Ok(_) => (),
+            Err(err) => match err {
+                DockerContainerWaitError { .. } => (),
+                _ => return Err(OrcaError::from(err)),
+            },
+        }
+
+        let mut result_info: RunInfo;
+        while {
+            result_info = self.get_info(pod_run).await?;
+            matches!(&result_info.status, Status::Running)
+        } {
+            sleep(Duration::from_millis(100)).await;
+        }
+
         PodResult::new(
             None,
             Arc::clone(&pod_run.pod_job),
@@ -209,7 +230,63 @@ impl Orchestrator for LocalDockerOrchestrator {
                 .context(selector::InvalidPodResultTerminatedDatetime {
                     pod_job_hash: pod_run.pod_job.hash.clone(),
                 })?,
+            self.get_logs(pod_run).await?,
         )
+    }
+    async fn get_logs(&self, pod_run: &PodRun) -> Result<String> {
+        let mut std_out = Vec::new();
+        let mut std_err = Vec::new();
+
+        self.api
+            .logs::<String>(
+                &pod_run.assigned_name,
+                Some(LogsOptions {
+                    stdout: true,
+                    stderr: true,
+                    ..Default::default()
+                }),
+            )
+            .try_collect::<Vec<_>>()
+            .await?
+            .iter()
+            .for_each(|log_output| match log_output {
+                LogOutput::StdOut { message } => {
+                    std_out.extend(message.to_vec());
+                }
+                LogOutput::StdErr { message } => {
+                    std_err.extend(message.to_vec());
+                }
+                LogOutput::StdIn { .. } | LogOutput::Console { .. } => {
+                    // Ignore stdin logs, as they are not relevant for our use case
+                }
+            });
+
+        let mut logs = String::from_utf8_lossy(&std_out).to_string();
+        if !std_err.is_empty() {
+            logs.push_str("\nSTDERR:\n");
+            logs.push_str(&String::from_utf8_lossy(&std_err));
+        }
+
+        // Check for errors in the docker state, if exist, attach it to logs
+        // This is for when the container exits immediately due to a bad command or similar
+        let error = self
+            .api
+            .inspect_container(&pod_run.assigned_name, None)
+            .await?
+            .state
+            .context(selector::FailedToExtractRunInfo {
+                container_name: &pod_run.assigned_name,
+            })?
+            .error
+            .context(selector::FailedToExtractRunInfo {
+                container_name: &pod_run.assigned_name,
+            })?;
+
+        if !error.is_empty() {
+            logs.push_str(&error);
+        }
+
+        Ok(logs)
     }
 }
 

--- a/src/uniffi/orchestrator/mod.rs
+++ b/src/uniffi/orchestrator/mod.rs
@@ -25,6 +25,8 @@ pub enum Status {
     Completed,
     /// Run failed with the provided error code.
     Failed(i16),
+    /// Deal with docker return status of restarting, removing, paused, and dead
+    Undefined,
     /// No status set.
     #[default]
     Unset,

--- a/src/uniffi/orchestrator/mod.rs
+++ b/src/uniffi/orchestrator/mod.rs
@@ -17,6 +17,8 @@ pub enum ImageKind {
 /// Status of a particular compute run.
 #[derive(uniffi::Enum, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 pub enum Status {
+    /// Container is created and is pending execution
+    Queued,
     /// Run is ongoing.
     Running,
     /// Run has completed successfully.
@@ -52,7 +54,7 @@ pub struct RunInfo {
     pub memory_limit: u64,
 }
 /// Current computation managed by orchestrator.
-#[derive(uniffi::Record, Debug)]
+#[derive(uniffi::Record, Debug, PartialEq)]
 pub struct PodRun {
     /// Original compute request.
     pub pod_job: Arc<PodJob>,
@@ -111,6 +113,10 @@ pub trait Orchestrator: Send + Sync {
     ///
     /// Will return `Err` if there is an issue creating a pod result.
     fn get_result_blocking(&self, pod_run: &PodRun) -> Result<PodResult>;
+    /// Get the logs for a specific pod run.
+    /// # Errors
+    /// Will return `Err` if there is an issue getting logs.
+    fn get_logs_blocking(&self, pod_run: &PodRun) -> Result<String>;
     /// How to asynchronously start containers with an alternate image.
     ///
     /// # Errors
@@ -156,6 +162,8 @@ pub trait Orchestrator: Send + Sync {
     ///
     /// Will return `Err` if there is an issue creating a pod result.
     async fn get_result(&self, pod_run: &PodRun) -> Result<PodResult>;
+    /// Get the logs for a specific pod run.
+    async fn get_logs(&self, pod_run: &PodRun) -> Result<String>;
 }
 
 /// Orchestration implementation for Docker backend.

--- a/src/uniffi/store/filestore.rs
+++ b/src/uniffi/store/filestore.rs
@@ -55,6 +55,11 @@ impl Store for LocalFileStore {
     }
     fn save_pod_result(&self, pod_result: &PodResult) -> Result<()> {
         self.save_pod_job(&pod_result.pod_job)?;
+        // Save the logs into a separate file.
+        Self::save_file(
+            self.make_path(pod_result, &pod_result.hash, "logs.txt"),
+            &pod_result.logs,
+        )?;
         self.save_model(pod_result, &pod_result.hash, pod_result.annotation.as_ref())
     }
     fn load_pod_result(&self, model_id: &ModelID) -> Result<PodResult> {
@@ -64,6 +69,8 @@ impl Store for LocalFileStore {
         pod_result.pod_job = self
             .load_pod_job(&ModelID::Hash(pod_result.pod_job.hash.clone()))?
             .into();
+        pod_result.logs =
+            fs::read_to_string(self.make_path(&pod_result, &pod_result.hash, "logs.txt"))?;
         Ok(pod_result)
     }
     fn list_pod_result(&self) -> Result<Vec<ModelInfo>> {

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -139,6 +139,7 @@ pub fn pod_result_style(
         Status::Completed,
         1_737_922_307,
         1_737_925_907,
+        String::from("Example logs"),
     )
 }
 

--- a/tests/orchestrator.rs
+++ b/tests/orchestrator.rs
@@ -2,10 +2,13 @@
 
 pub mod fixture;
 use fixture::{TestDirs, container_image_style, pod_job_style};
-use orcapod::uniffi::{
-    error::Result,
-    model::URI,
-    orchestrator::{ImageKind, Orchestrator, PodRun, Status, docker::LocalDockerOrchestrator},
+use orcapod::{
+    core::{crypto::hash_buffer, model::to_yaml},
+    uniffi::{
+        error::Result,
+        model::URI,
+        orchestrator::{ImageKind, Orchestrator, PodRun, Status, docker::LocalDockerOrchestrator},
+    },
 };
 use std::{collections::HashMap, ops::Deref as _, path::PathBuf, sync::Arc};
 fn execute_wrapper<T>(test_fn: T) -> Result<()>
@@ -134,13 +137,21 @@ fn logs() -> Result<()> {
     execute_wrapper(|namespace_lookup, orchestrator| {
         let mut pod_job = pod_job_style(namespace_lookup)?;
 
+        // Update pod
         let mut pod = pod_job.pod.deref().clone();
         pod.image = "alpine:3.14".to_owned();
         pod.command = "echo hi1".to_owned();
         pod.input_spec = HashMap::new();
-        pod_job.pod = pod.into();
+        // Update the hash
+        pod.hash = String::new();
+        pod.hash = hash_buffer(to_yaml(&pod)?);
 
+        // Update pod job
+        pod_job.pod = pod.into();
         pod_job.input_packet = HashMap::new();
+        // Update the hash
+        pod_job.hash = String::new();
+        pod_job.hash = hash_buffer(to_yaml(&pod_job)?);
 
         let pod_run = orchestrator.start_blocking(namespace_lookup, &pod_job)?;
         let pod_result = orchestrator.get_result_blocking(&pod_run)?;

--- a/tests/orchestrator.rs
+++ b/tests/orchestrator.rs
@@ -1,20 +1,16 @@
 #![expect(missing_docs, clippy::panic_in_result_fn, reason = "OK in tests.")]
 
 pub mod fixture;
-use fixture::{TestContainerImage, TestDirs, container_image_style, pod_job_style};
+use fixture::{TestDirs, container_image_style, pod_job_style};
 use orcapod::uniffi::{
     error::Result,
     model::URI,
-    orchestrator::{ImageKind, Orchestrator as _, PodRun, Status, docker::LocalDockerOrchestrator},
+    orchestrator::{ImageKind, Orchestrator, PodRun, Status, docker::LocalDockerOrchestrator},
 };
 use std::{collections::HashMap, ops::Deref as _, path::PathBuf, sync::Arc};
-
-fn basic_test<T>(start: T) -> Result<()>
+fn execute_wrapper<T>(test_fn: T) -> Result<()>
 where
-    T: Fn(
-        &HashMap<String, PathBuf>,
-        &LocalDockerOrchestrator,
-    ) -> Result<(PodRun, String, Option<TestContainerImage>)>,
+    T: Fn(&HashMap<String, PathBuf>, &LocalDockerOrchestrator) -> Result<()>,
 {
     let test_dirs = TestDirs::new(&HashMap::from([(
         "default".to_owned(),
@@ -22,9 +18,17 @@ where
     )]))?;
     let namespace_lookup = test_dirs.namespace_lookup();
     let orchestrator = LocalDockerOrchestrator::new()?;
-    let (pod_run, expected_command, _container_image) = start(&namespace_lookup, &orchestrator)?;
+
+    test_fn(&namespace_lookup, &orchestrator)
+}
+
+fn basic_test(
+    pod_run: &PodRun,
+    expected_command: &str,
+    orchestrator: &impl Orchestrator,
+) -> Result<()> {
     assert_eq!(
-        orchestrator.get_info_blocking(&pod_run)?.status,
+        orchestrator.get_info_blocking(pod_run)?.status,
         Status::Running,
         "Unexpected state."
     );
@@ -32,15 +36,16 @@ where
         orchestrator
             .list_blocking()?
             .iter()
+            .filter(|run| **run == *pod_run)
             .map(|run| Ok(orchestrator.get_info_blocking(run)?.command))
             .collect::<Result<Vec<_>>>()?,
-        vec![expected_command.clone()],
+        vec![expected_command],
         "Unexpected list."
     );
     // await result
-    let pod_result_1 = orchestrator.get_result_blocking(&pod_run)?;
+    let pod_result_1 = orchestrator.get_result_blocking(pod_run)?;
     assert_eq!(
-        orchestrator.get_info_blocking(&pod_run)?.status,
+        orchestrator.get_info_blocking(pod_run)?.status,
         Status::Completed,
         "Unexpected state."
     );
@@ -48,6 +53,7 @@ where
         orchestrator
             .list_blocking()?
             .iter()
+            .filter(|run| **run == *pod_run)
             .map(|run| Ok(orchestrator.get_info_blocking(run)?.command))
             .collect::<Result<Vec<_>>>()?,
         vec![expected_command],
@@ -58,18 +64,18 @@ where
         "Unexpected name."
     );
     // try generating result again
-    let pod_result_2 = orchestrator.get_result_blocking(&pod_run)?;
+    let pod_result_2 = orchestrator.get_result_blocking(pod_run)?;
     assert_eq!(pod_result_1, pod_result_2, "Pod results don't match.");
     // test delete
-    orchestrator.delete_blocking(&pod_run)?;
+    orchestrator.delete_blocking(pod_run)?;
     assert!(
-        orchestrator.list_blocking()?.is_empty(),
+        !orchestrator.list_blocking()?.contains(pod_run),
         "Unexpected container remains."
     );
     // try getting info of a purged pod run
     assert!(
         orchestrator
-            .get_info_blocking(&pod_run)
+            .get_info_blocking(pod_run)
             .is_err_and(|error| error.is_purged_pod_run() && !format!("{error:?}").is_empty()),
         "Did not raise a purged pod run error."
     );
@@ -78,32 +84,34 @@ where
 
 #[test]
 fn offline_container_image_basic() -> Result<()> {
-    basic_test(|namespace_lookup, orchestrator| {
+    execute_wrapper(|namespace_lookup, orchestrator| {
         let container_image_relative_location = "container_images/style-transfer/image.tar.gz";
         let container_image_kind = ImageKind::Tarball(URI {
             namespace: "default".to_owned(),
             path: PathBuf::from(container_image_relative_location),
         });
-        let container_image = container_image_style(
+        let _container_image = container_image_style(
             namespace_lookup["default"].join(container_image_relative_location),
         )?;
         let mut pod_job = pod_job_style(namespace_lookup)?;
-        pod_job.env_vars = Some(HashMap::from([("DELAY".to_owned(), "5".to_owned())]));
-        Ok((
-            orchestrator.start_with_altimage_blocking(
+        pod_job.env_vars = Some(HashMap::from([("DELAY".to_owned(), "1".to_owned())]));
+
+        basic_test(
+            &orchestrator.start_with_altimage_blocking(
                 namespace_lookup,
                 &pod_job,
                 &container_image_kind,
             )?,
-            pod_job.pod.command.clone(),
-            Some(container_image),
-        ))
+            &pod_job.pod.command,
+            orchestrator,
+        )?;
+        Ok(())
     })
 }
 
 #[test]
 fn remote_container_image_basic() -> Result<()> {
-    basic_test(|namespace_lookup, orchestrator| {
+    execute_wrapper(|namespace_lookup, orchestrator| {
         let mut pod_job = pod_job_style(namespace_lookup)?;
         let mut pod = pod_job.pod.deref().clone();
         pod.image = "alpine:3.14".to_owned();
@@ -111,10 +119,48 @@ fn remote_container_image_basic() -> Result<()> {
         pod.input_spec = HashMap::new();
         pod_job.pod = Arc::new(pod);
         pod_job.input_packet = HashMap::new();
-        Ok((
-            orchestrator.start_blocking(namespace_lookup, &pod_job)?,
-            pod_job.pod.command.clone(),
-            None,
-        ))
+
+        basic_test(
+            &orchestrator.start_blocking(namespace_lookup, &pod_job)?,
+            &pod_job.pod.command,
+            orchestrator,
+        )?;
+        Ok(())
+    })
+}
+
+#[test]
+fn logs() -> Result<()> {
+    execute_wrapper(|namespace_lookup, orchestrator| {
+        let mut pod_job = pod_job_style(namespace_lookup)?;
+
+        let mut pod = pod_job.pod.deref().clone();
+        pod.image = "alpine:3.14".to_owned();
+        pod.command = "echo hi1".to_owned();
+        pod.input_spec = HashMap::new();
+        pod_job.pod = pod.into();
+
+        pod_job.input_packet = HashMap::new();
+
+        let pod_run = orchestrator.start_blocking(namespace_lookup, &pod_job)?;
+        let pod_result = orchestrator.get_result_blocking(&pod_run)?;
+
+        assert_eq!(
+            pod_result.status,
+            Status::Completed,
+            "Pod status is not completed"
+        );
+
+        assert_eq!(orchestrator.get_logs_blocking(&pod_run)?, "hi1\n");
+        assert_eq!(orchestrator.get_result_blocking(&pod_run)?.logs, "hi1\n");
+
+        orchestrator.delete_blocking(&pod_run)?;
+
+        assert!(
+            !orchestrator.list_blocking()?.contains(&pod_run),
+            "Unexpected container remains."
+        );
+
+        Ok(())
     })
 }


### PR DESCRIPTION
Added:
- get_logs() and get_logs_blocking() that query the logs from the docker API
- Add status Undefined for status to deal with docker api possible return status of restarting, removing, paused, and dead
- Change basic_test to be only asserts, and added excuter_wrapper to handle fixture scaffolding
- Fix basic test assert to list by pod_run as discussed on Friday to avoid collisions
- Add a basic test for log functionality.
- Log are save as a log.txt when saved to disk, and is read back into memory upon loading
- Added hash updating to the logging test.