### PR TITLE
`Agent`: Add configurable storage of `PodResult`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ chrono = "0.4.39"
 colored = "2.1.0"
 # derive utilities for new types
 derive_more = { version = "2.0.1", features = ["display"] }
+# allow sync functions to be called from async using `block_on`
+futures-executor = "0.3.31"
 # chaining async calls and processing stream data in local docker orchestrator
 futures-util = "0.3.31"
 # auto derive getter access methods on structs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,6 @@ chrono = "0.4.39"
 colored = "2.1.0"
 # derive utilities for new types
 derive_more = { version = "2.0.1", features = ["display"] }
-# allow sync functions to be called from async using `block_on`
-futures-executor = "0.3.31"
 # chaining async calls and processing stream data in local docker orchestrator
 futures-util = "0.3.31"
 # auto derive getter access methods on structs

--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,7 @@
         "cffi",
         "zenoh",
         "PodJob",
+        "stresser"
     ],
     "ignoreWords": [
         "relpath",

--- a/src/core/orchestrator/agent.rs
+++ b/src/core/orchestrator/agent.rs
@@ -123,8 +123,9 @@ pub async fn start_service<
 ) -> Result<()>
 where
     EventClassifierF: Fn(&RequestI) -> EventPayload + Send + 'static,
-    RequestI: for<'serde> Deserialize<'serde>,
-    RequestF: Fn(Arc<Agent>, HashMap<String, PathBuf>, EventMetadata, RequestI) -> RequestR
+    RequestI: for<'serde> Deserialize<'serde> + Send + 'static,
+    RequestF: FnOnce(Arc<Agent>, HashMap<String, PathBuf>, EventMetadata, RequestI) -> RequestR
+        + Clone
         + Send
         + 'static,
     RequestR: Future<Output = Result<ResponseI>> + Send + 'static,
@@ -164,19 +165,25 @@ where
                         subgroup: metadata["pod_job_hash"].to_string(),
                     };
                     let _event_payload = event_classifier(&input);
-                    tasks.spawn(
-                        request_task(
-                            Arc::clone(&inner_agent),
-                            namespace_lookup.clone(),
-                            event_metadata,
-                            input,
-                        )
-                        .then(move |response| async move {
-                            let _: Result<(), SendError<Result<ResponseI>>> =
-                                inner_response_tx.send(response).await;
-                            Ok::<_, OrcaError>(())
-                        }),
-                    );
+                    tasks.spawn({
+                        let inner_request_task = request_task.clone();
+                        let inner_inner_agent = Arc::clone(&inner_agent);
+                        let inner_namespace_lookup = namespace_lookup.clone();
+                        async move {
+                            inner_request_task(
+                                inner_inner_agent,
+                                inner_namespace_lookup,
+                                event_metadata,
+                                input,
+                            )
+                            .then(move |response| async move {
+                                let _: Result<(), SendError<Result<ResponseI>>> =
+                                    inner_response_tx.send(response).await;
+                                Ok::<_, OrcaError>(())
+                            })
+                            .await
+                        }
+                    });
                 }
             }
             Ok(())

--- a/src/core/orchestrator/docker.rs
+++ b/src/core/orchestrator/docker.rs
@@ -170,6 +170,7 @@ impl LocalDockerOrchestrator {
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
         clippy::indexing_slicing,
+        clippy::too_many_lines,
         reason = r#"
         - Timestamp and memory should always have a value > 0
         - Container will always have a name with more than 1 character
@@ -210,13 +211,13 @@ impl LocalDockerOrchestrator {
             let terminated_timestamp =
                 DateTime::parse_from_rfc3339(container_spec.state.as_ref()?.finished_at.as_ref()?)
                     .ok()?
-                    .timestamp() as u64;
+                    .timestamp();
             Some((
                 container_name,
                 RunInfo {
                     image: container_spec.config.as_ref()?.image.as_ref()?.clone(),
                     created: container_summary.created? as u64,
-                    terminated: (terminated_timestamp > 0).then_some(terminated_timestamp),
+                    terminated: (terminated_timestamp > 0).then_some(terminated_timestamp as u64),
                     env_vars: container_spec
                         .config
                         .as_ref()?
@@ -243,9 +244,20 @@ impl LocalDockerOrchestrator {
                         container_spec.state.as_ref()?.exit_code? as i16,
                     ) {
                         (ContainerStateStatusEnum::RUNNING, _) => Status::Running,
-                        (ContainerStateStatusEnum::EXITED, 0) => Status::Completed,
-                        (ContainerStateStatusEnum::EXITED, code) => Status::Failed(code),
-                        _ => todo!(),
+                        (
+                            ContainerStateStatusEnum::EXITED | ContainerStateStatusEnum::REMOVING,
+                            0,
+                        ) => Status::Completed,
+                        (
+                            ContainerStateStatusEnum::EXITED | ContainerStateStatusEnum::REMOVING,
+                            code,
+                        ) => Status::Failed(code),
+                        (_, code) => {
+                            todo!(
+                                "Unhandled container state: {}, exit code: {code}.",
+                                container_spec.state.as_ref()?.status.as_ref()?
+                            )
+                        }
                     },
                     mounts: container_spec
                         .mounts

--- a/src/uniffi/orchestrator/agent.rs
+++ b/src/uniffi/orchestrator/agent.rs
@@ -1,5 +1,8 @@
 use crate::{
-    core::orchestrator::agent::{EventPayload, start_service},
+    core::orchestrator::{
+        ASYNC_RUNTIME,
+        agent::{EventPayload, start_service},
+    },
     uniffi::{
         error::{OrcaError, Result, selector},
         model::{PodJob, PodResult},
@@ -8,13 +11,12 @@ use crate::{
     },
 };
 use derive_more::Display;
-use futures_executor::block_on;
 use futures_util::future::join_all;
 use getset::CloneGetters;
 use serde_json::Value;
 use snafu::{OptionExt as _, ResultExt as _};
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
-use tokio::task::JoinSet;
+use tokio::{runtime::Handle, task::JoinSet};
 use uniffi;
 use zenoh;
 
@@ -58,10 +60,13 @@ impl AgentClient {
     /// Will fail if there is an issue initializing a session.
     #[uniffi::constructor]
     pub fn new(group: String, host: String) -> Result<Self> {
+        let handle = Handle::try_current()
+            .ok()
+            .unwrap_or_else(|| ASYNC_RUNTIME.handle().clone());
         Ok(Self {
             group,
             host,
-            session: block_on(async {
+            session: handle.block_on(async {
                 Ok::<_, OrcaError>(
                     zenoh::open(zenoh::Config::default())
                         .await

--- a/src/uniffi/orchestrator/agent.rs
+++ b/src/uniffi/orchestrator/agent.rs
@@ -127,6 +127,7 @@ impl Agent {
     /// # Errors
     ///
     /// Will stop and return an error if encounters an error while processing any pod job request.
+    #[expect(clippy::excessive_nesting, reason = "Nesting manageable.")]
     pub async fn start(
         &self,
         namespace_lookup: &HashMap<String, PathBuf>,
@@ -160,14 +161,23 @@ impl Agent {
         if let Some(store) = available_store {
             services.spawn(start_service(
                 Arc::new(self.clone()),
-                "{success,failure}/pod_job/**".to_owned(),
+                "success/pod_job/**".to_owned(),
                 namespace_lookup.clone(),
-                |pod_result: &PodResult| match pod_result.status {
-                    Status::Completed => EventPayload::Success(pod_result.clone()),
-                    Status::Running | Status::Failed(_) | Status::Unset => {
-                        EventPayload::Failure(pod_result.clone())
+                |pod_result: &PodResult| EventPayload::Success(pod_result.clone()),
+                {
+                    let inner_store = Arc::clone(&store);
+                    async move |_, _, _, pod_result| {
+                        inner_store.save_pod_result(&pod_result)?;
+                        Ok(())
                     }
                 },
+                async |_, ()| Ok(()),
+            ));
+            services.spawn(start_service(
+                Arc::new(self.clone()),
+                "failure/pod_job/**".to_owned(),
+                namespace_lookup.clone(),
+                |pod_result: &PodResult| EventPayload::Failure(pod_result.clone()),
                 async move |_, _, _, pod_result| {
                     store.save_pod_result(&pod_result)?;
                     Ok(())

--- a/src/uniffi/orchestrator/agent.rs
+++ b/src/uniffi/orchestrator/agent.rs
@@ -1,8 +1,5 @@
 use crate::{
-    core::orchestrator::{
-        ASYNC_RUNTIME,
-        agent::{EventPayload, start_service},
-    },
+    core::orchestrator::agent::{EventPayload, start_service},
     uniffi::{
         error::{OrcaError, Result, selector},
         model::{PodJob, PodResult},
@@ -11,12 +8,13 @@ use crate::{
     },
 };
 use derive_more::Display;
+use futures_executor::block_on;
 use futures_util::future::join_all;
 use getset::CloneGetters;
 use serde_json::Value;
 use snafu::{OptionExt as _, ResultExt as _};
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
-use tokio::{runtime::Handle, task::JoinSet};
+use tokio::task::JoinSet;
 use uniffi;
 use zenoh;
 
@@ -60,13 +58,10 @@ impl AgentClient {
     /// Will fail if there is an issue initializing a session.
     #[uniffi::constructor]
     pub fn new(group: String, host: String) -> Result<Self> {
-        let handle = Handle::try_current()
-            .ok()
-            .unwrap_or_else(|| ASYNC_RUNTIME.handle().clone());
         Ok(Self {
             group,
             host,
-            session: handle.block_on(async {
+            session: block_on(async {
                 Ok::<_, OrcaError>(
                     zenoh::open(zenoh::Config::default())
                         .await

--- a/src/uniffi/orchestrator/agent.rs
+++ b/src/uniffi/orchestrator/agent.rs
@@ -18,6 +18,19 @@ use tokio::task::JoinSet;
 use uniffi;
 use zenoh;
 
+/// A response, similar to Rust's `Result` but casting error to `String`.
+///
+/// This is a workaround due to `UniFFI` limitations when trying to send a collection of `Result`
+/// over the CFFI boundary e.g. concurrent calls where it is necessary to know the status of each
+/// request to determine what to retry.
+#[derive(uniffi::Enum)]
+pub enum Response {
+    /// Success
+    Ok,
+    /// Error cast to `String`
+    Err(String),
+}
+
 /// Client to connect to an execution agent within a coordinated fleet. Connection optimized/rerouted by Zenoh.
 #[expect(
     clippy::field_scoped_visibility_modifiers,
@@ -59,14 +72,14 @@ impl AgentClient {
     }
     /// Submit many pod jobs to be processed in parallel.
     /// Return order will match inputs, casting outputs to `String` (since `uniffi` doesn't support sending unwrapped `Result`s).
-    pub async fn submit_pod_jobs(&self, pod_jobs: Vec<Arc<PodJob>>) -> Vec<String> {
+    pub async fn submit_pod_jobs(&self, pod_jobs: Vec<Arc<PodJob>>) -> Vec<Response> {
         join_all(pod_jobs.iter().map(|pod_job| async {
             match self
                 .publish(&format!("request/pod_job/{}", pod_job.hash), pod_job)
                 .await
             {
-                Ok(()) => "ok".into(),
-                Err(error) => error.to_string(),
+                Ok(()) => Response::Ok,
+                Err(error) => Response::Err(error.to_string()),
             }
         }))
         .await

--- a/src/uniffi/orchestrator/agent.rs
+++ b/src/uniffi/orchestrator/agent.rs
@@ -2,8 +2,9 @@ use crate::{
     core::orchestrator::agent::{EventPayload, start_service},
     uniffi::{
         error::{OrcaError, Result, selector},
-        model::PodJob,
+        model::{PodJob, PodResult},
         orchestrator::{Orchestrator, Status, docker::LocalDockerOrchestrator},
+        store::{Store as _, filestore::LocalFileStore},
     },
 };
 use derive_more::Display;
@@ -126,13 +127,17 @@ impl Agent {
     /// # Errors
     ///
     /// Will stop and return an error if encounters an error while processing any pod job request.
-    pub async fn start(&self, namespace_lookup: &HashMap<String, PathBuf>) -> Result<()> {
+    pub async fn start(
+        &self,
+        namespace_lookup: &HashMap<String, PathBuf>,
+        available_store: Option<Arc<LocalFileStore>>,
+    ) -> Result<()> {
         let mut services = JoinSet::new();
         services.spawn(start_service(
             Arc::new(self.clone()),
             "request/pod_job/**".to_owned(),
             namespace_lookup.clone(),
-            |input: &PodJob| EventPayload::Request(input.clone()),
+            |pod_job: &PodJob| EventPayload::Request(pod_job.clone()),
             async |agent, inner_namespace_lookup, _, pod_job| {
                 let pod_run = agent
                     .orchestrator
@@ -152,6 +157,24 @@ impl Agent {
                 client.publish(response_topic, &pod_result).await
             },
         ));
+        if let Some(store) = available_store {
+            services.spawn(start_service(
+                Arc::new(self.clone()),
+                "{success,failure}/pod_job/**".to_owned(),
+                namespace_lookup.clone(),
+                |pod_result: &PodResult| match pod_result.status {
+                    Status::Completed => EventPayload::Success(pod_result.clone()),
+                    Status::Running | Status::Failed(_) | Status::Unset => {
+                        EventPayload::Failure(pod_result.clone())
+                    }
+                },
+                async move |_, _, _, pod_result| {
+                    store.save_pod_result(&pod_result)?;
+                    Ok(())
+                },
+                async |_, ()| Ok(()),
+            ));
+        }
         services
             .join_next()
             .await

--- a/src/uniffi/orchestrator/docker.rs
+++ b/src/uniffi/orchestrator/docker.rs
@@ -6,7 +6,7 @@ use crate::{
     uniffi::{
         error::{OrcaError, Result, selector},
         model::{PodJob, PodResult},
-        orchestrator::{ImageKind, Orchestrator, PodRun, RunInfo},
+        orchestrator::{ImageKind, Orchestrator, PodRun, RunInfo, Status},
     },
 };
 use async_trait;
@@ -18,8 +18,8 @@ use bollard::{
 use derive_more::Display;
 use futures_util::stream::{StreamExt as _, TryStreamExt as _};
 use snafu::{OptionExt as _, futures::TryFutureExt as _};
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
-use tokio::fs::File;
+use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+use tokio::{fs::File, time::sleep as async_sleep};
 use tokio_util::{
     bytes::{Bytes, BytesMut},
     codec::{BytesCodec, FramedRead},
@@ -197,7 +197,15 @@ impl Orchestrator for LocalDockerOrchestrator {
             .wait_container(&pod_run.assigned_name, None::<WaitContainerOptions<String>>)
             .try_collect::<Vec<_>>()
             .await?;
-        let result_info = self.get_info(pod_run).await?;
+
+        let mut result_info: RunInfo;
+        while {
+            result_info = self.get_info(pod_run).await?;
+            matches!(&result_info.status, Status::Running)
+        } {
+            async_sleep(Duration::from_millis(100)).await;
+        }
+
         PodResult::new(
             None,
             Arc::clone(&pod_run.pod_job),

--- a/src/uniffi/orchestrator/docker.rs
+++ b/src/uniffi/orchestrator/docker.rs
@@ -13,6 +13,7 @@ use async_trait;
 use bollard::{
     Docker,
     container::{RemoveContainerOptions, StartContainerOptions, WaitContainerOptions},
+    errors::Error::DockerContainerWaitError,
     image::{CreateImageOptions, ImportImageOptions},
 };
 use derive_more::Display;
@@ -192,11 +193,23 @@ impl Orchestrator for LocalDockerOrchestrator {
             })?;
         Ok(run_info)
     }
+    #[expect(
+        clippy::wildcard_enum_match_arm,
+        reason = "Favor readability due to complexity in external dependency."
+    )]
     async fn get_result(&self, pod_run: &PodRun) -> Result<PodResult> {
-        self.api
+        match self
+            .api
             .wait_container(&pod_run.assigned_name, None::<WaitContainerOptions<String>>)
             .try_collect::<Vec<_>>()
-            .await?;
+            .await
+        {
+            Ok(_) => (),
+            Err(err) => match err {
+                DockerContainerWaitError { .. } => (),
+                _ => return Err(OrcaError::from(err)),
+            },
+        }
 
         let mut result_info: RunInfo;
         while {

--- a/src/uniffi/store/filestore.rs
+++ b/src/uniffi/store/filestore.rs
@@ -8,7 +8,7 @@ use getset::CloneGetters;
 use std::{fs, path::PathBuf};
 use uniffi;
 /// Support for a storage backend on a local filesystem directory.
-#[derive(uniffi::Object, Debug, Display, CloneGetters)]
+#[derive(uniffi::Object, Debug, Display, CloneGetters, Clone)]
 #[getset(get_clone, impl_attrs = "#[uniffi::export]")]
 #[display("{self:#?}")]
 #[uniffi::export(Display)]

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -83,34 +83,44 @@ async fn parallel_four_cores() -> Result<()> {
             .await
             .expect("Unable to create a zenoh session.");
         let subscriber = session
-            .declare_subscriber(&format!("group/{group}/success/pod_job/**"))
+            .declare_subscriber(&format!("group/{group}/*/pod_job/**"))
             .await
             .expect("Unable to create subscriber.");
-        let mut counter = 0;
+        let mut success_counter = 0;
+        let mut failure_counter = 0;
         while let Ok(sample) = subscriber.recv_async().await {
-            counter += 1;
-            let pod_result = serde_json::from_slice::<PodResult>(&sample.payload().to_bytes())?;
-            assert!(
-                u128::from(pod_result.created * 1000)
-                    <= current_timestamp + margin_millis + u128::from(service_readiness_delay_secs),
-                "Started pod run too late."
-            );
-            assert!(
-                u128::from(pod_result.terminated * 1000)
-                    <= current_timestamp
-                        + 2 * margin_millis
-                        + u128::from(run_duration_secs) * 1000
-                        + u128::from(service_readiness_delay_secs),
-                "Took too long to finish pod run."
-            );
-            async_sleep(Duration::from_secs(1)).await; // give agent a chance to save pod result first
-            assert_eq!(
-                store.load_pod_result(&ModelID::Hash(pod_result.hash.clone()))?,
-                pod_result,
-                "Stored pod result does not match."
-            );
-            if counter == 4 {
-                break;
+            let topic_kind = sample.key_expr().as_str().split('/').collect::<Vec<_>>()[2];
+            if ["success", "failure"].contains(&topic_kind) {
+                let pod_result = serde_json::from_slice::<PodResult>(&sample.payload().to_bytes())?;
+                assert!(
+                    u128::from(pod_result.created * 1000)
+                        <= current_timestamp
+                            + margin_millis
+                            + u128::from(service_readiness_delay_secs),
+                    "Started pod run too late."
+                );
+                assert!(
+                    u128::from(pod_result.terminated * 1000)
+                        <= current_timestamp
+                            + 2 * margin_millis
+                            + u128::from(run_duration_secs) * 1000
+                            + u128::from(service_readiness_delay_secs),
+                    "Took too long to finish pod run."
+                );
+                async_sleep(Duration::from_secs(1)).await; // give agent a chance to save pod result first
+                assert_eq!(
+                    store.load_pod_result(&ModelID::Hash(pod_result.hash.clone()))?,
+                    pod_result,
+                    "Stored pod result does not match."
+                );
+                if topic_kind == "success" {
+                    success_counter += 1;
+                } else {
+                    failure_counter += 1;
+                }
+                if success_counter == 3 && failure_counter == 1 {
+                    break;
+                }
             }
         }
         Ok(())
@@ -122,7 +132,7 @@ async fn parallel_four_cores() -> Result<()> {
     async_sleep(Duration::from_secs(service_readiness_delay_secs)).await;
     // submit requests
     client
-        .submit_pod_jobs(pod_jobs_stresser(image_reference, run_duration_secs, 4)?)
+        .submit_pod_jobs(pod_jobs_stresser(image_reference, run_duration_secs, 3, 1)?)
         .await;
 
     services

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -3,11 +3,12 @@
     clippy::panic_in_result_fn,
     clippy::panic,
     clippy::expect_used,
+    clippy::indexing_slicing,
     reason = "OK in tests."
 )]
 
 pub mod fixture;
-use fixture::{NAMESPACE_LOOKUP_READ_ONLY, pull_image};
+use fixture::{NAMESPACE_LOOKUP_READ_ONLY, TestDirs, pull_image};
 use orcapod::uniffi::{
     error::Result,
     model::{Annotation, Pod, PodJob, PodResult, URI},
@@ -15,6 +16,7 @@ use orcapod::uniffi::{
         agent::{Agent, AgentClient},
         docker::LocalDockerOrchestrator,
     },
+    store::{ModelID, Store as _, filestore::LocalFileStore},
 };
 use std::{
     collections::HashMap,
@@ -41,6 +43,8 @@ fn simple() -> Result<()> {
 #[expect(clippy::excessive_nesting, reason = "Nesting is manageable")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn parallel_four_cores() -> Result<()> {
+    let test_dirs = TestDirs::new(&HashMap::from([("default".to_owned(), None::<String>)]))?;
+    let store = LocalFileStore::new(test_dirs.0["default"].path().to_path_buf());
     // config
     let image_reference = "ghcr.io/colinianking/stress-ng:e2f96874f951a72c1c83ff49098661f0e013ac40";
     pull_image(image_reference)?;
@@ -68,7 +72,12 @@ async fn parallel_four_cores() -> Result<()> {
     });
     services.spawn({
         let inner_agent = agent.clone();
-        async move { inner_agent.start(&NAMESPACE_LOOKUP_READ_ONLY).await }
+        let inner_store = store.clone();
+        async move {
+            inner_agent
+                .start(&NAMESPACE_LOOKUP_READ_ONLY, Some(inner_store.into()))
+                .await
+        }
     });
     services.spawn(async move {
         let session = zenoh::open(zenoh::Config::default())
@@ -94,6 +103,10 @@ async fn parallel_four_cores() -> Result<()> {
                         + run_duration_secs * 1000
                         + u128::from(service_readiness_delay_secs),
                 "Took too long to finish pod run."
+            );
+            assert!(
+                pod_result == store.load_pod_result(&ModelID::Hash(pod_result.hash.clone()))?,
+                "Stored pod result does not match."
             );
             if counter == 4 {
                 break;

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -8,10 +8,10 @@
 )]
 
 pub mod fixture;
-use fixture::{NAMESPACE_LOOKUP_READ_ONLY, TestDirs, pull_image};
+use fixture::{NAMESPACE_LOOKUP_READ_ONLY, TestDirs, pod_jobs_stresser, pull_image};
 use orcapod::uniffi::{
     error::Result,
-    model::{Annotation, Pod, PodJob, PodResult, URI},
+    model::PodResult,
     orchestrator::{
         agent::{Agent, AgentClient},
         docker::LocalDockerOrchestrator,
@@ -20,7 +20,6 @@ use orcapod::uniffi::{
 };
 use std::{
     collections::HashMap,
-    path::PathBuf,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -41,10 +40,10 @@ fn simple() -> Result<()> {
 }
 
 #[expect(clippy::excessive_nesting, reason = "Nesting is manageable")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn parallel_four_cores() -> Result<()> {
     let test_dirs = TestDirs::new(&HashMap::from([("default".to_owned(), None::<String>)]))?;
-    let store = LocalFileStore::new(test_dirs.0["default"].path().to_path_buf());
+    let store = LocalFileStore::new(test_dirs.0["default"].path().into());
     // config
     let image_reference = "ghcr.io/colinianking/stress-ng:e2f96874f951a72c1c83ff49098661f0e013ac40";
     pull_image(image_reference)?;
@@ -100,12 +99,14 @@ async fn parallel_four_cores() -> Result<()> {
                 u128::from(pod_result.terminated * 1000)
                     <= current_timestamp
                         + 2 * margin_millis
-                        + run_duration_secs * 1000
+                        + u128::from(run_duration_secs) * 1000
                         + u128::from(service_readiness_delay_secs),
                 "Took too long to finish pod run."
             );
-            assert!(
-                pod_result == store.load_pod_result(&ModelID::Hash(pod_result.hash.clone()))?,
+            async_sleep(Duration::from_secs(1)).await; // give agent a chance to save pod result first
+            assert_eq!(
+                store.load_pod_result(&ModelID::Hash(pod_result.hash.clone()))?,
+                pod_result,
                 "Stored pod result does not match."
             );
             if counter == 4 {
@@ -120,44 +121,9 @@ async fn parallel_four_cores() -> Result<()> {
     });
     async_sleep(Duration::from_secs(service_readiness_delay_secs)).await;
     // submit requests
-    let pod_jobs = (1..5)
-        .map(|i| {
-            Ok(Arc::new(PodJob::new(
-                Some(Annotation {
-                    name: "simple".to_owned(),
-                    description: "This is an example pod job.".to_owned(),
-                    version: format!("0.{i}.0"),
-                }),
-                Pod::new(
-                    Some(Annotation {
-                        name: "simple".to_owned(),
-                        description: "This is an example pod.".to_owned(),
-                        version: format!("{i}.0.0"),
-                    }),
-                    image_reference.into(),
-                    format!("stress-ng --cpu 1 --cpu-load 100 --timeout {run_duration_secs} --metrics-brief"),
-                    HashMap::new(),
-                    PathBuf::from("/tmp/output"),
-                    HashMap::new(),
-                    "https://github.com/user/simple".to_owned(),
-                    0.1,          // 100 millicores as frac cores
-                    10_u64 << 20, // 10 MiB in bytes
-                    None,
-                )?
-                .into(),
-                HashMap::new(),
-                URI {
-                    namespace: "default".to_owned(),
-                    path: PathBuf::from("."),
-                },
-                1.0,          // 1000 millicores as frac cores
-                10_u64 << 20, // 2GiB in bytes, KiB=<<10, MiB=<<20, GiB=<<30
-                None,
-                &NAMESPACE_LOOKUP_READ_ONLY,
-            )?))
-        })
-        .collect::<Result<Vec<_>>>()?;
-    client.submit_pod_jobs(pod_jobs).await;
+    client
+        .submit_pod_jobs(pod_jobs_stresser(image_reference, run_duration_secs, 4)?)
+        .await;
 
     services
         .join_next()

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -12,7 +12,11 @@ use orcapod::{
     core::crypto::hash_file,
     uniffi::{
         error::{OrcaError, Result},
-        orchestrator::{Orchestrator as _, agent::AgentClient, docker::LocalDockerOrchestrator},
+        orchestrator::{
+            Orchestrator as _,
+            agent::{AgentClient, Response},
+            docker::LocalDockerOrchestrator,
+        },
     },
 };
 use serde_json;
@@ -131,7 +135,10 @@ async fn submit_pod_jobs() -> Result<()> {
         "Client received an unexpected number of pod job request responses."
     );
     assert!(
-        responses[0].contains("Agent encountered a communication error."),
+        match &responses[0] {
+            Response::Ok => false,
+            Response::Err(message) => message.contains("Agent encountered a communication error."),
+        },
         "Client did not experience expected publish error."
     );
     Ok(())

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,13 +1,18 @@
-#![expect(missing_docs, clippy::panic_in_result_fn, reason = "OK in tests.")]
+#![expect(
+    missing_docs,
+    clippy::panic_in_result_fn,
+    clippy::indexing_slicing,
+    reason = "OK in tests."
+)]
 
 pub mod fixture;
-use fixture::{NAMESPACE_LOOKUP_READ_ONLY, pod_job_style};
+use fixture::{NAMESPACE_LOOKUP_READ_ONLY, pod_job_custom, pod_job_style};
 use glob::glob;
 use orcapod::{
     core::crypto::hash_file,
     uniffi::{
         error::{OrcaError, Result},
-        orchestrator::{Orchestrator as _, docker::LocalDockerOrchestrator},
+        orchestrator::{Orchestrator as _, agent::AgentClient, docker::LocalDockerOrchestrator},
     },
 };
 use serde_json;
@@ -86,6 +91,19 @@ async fn external_tokio_task() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn internal_agent_communication_failure() -> Result<()> {
+    let client = AgentClient::new("error".into(), "host".into())?;
+    assert!(
+        client
+            .watch("oh?no".into())
+            .await
+            .is_err_and(contains_debug),
+        "Did not raise an agent communication failure error."
+    );
+    Ok(())
+}
+
 #[test]
 fn internal_invalid_filepath() {
     assert!(
@@ -100,4 +118,21 @@ fn internal_key_missing() {
         pod_job_style(&HashMap::new()).is_err_and(contains_debug),
         "Did not raise a key missing error."
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn submit_pod_jobs() -> Result<()> {
+    let client = AgentClient::new("error".into(), "host".into())?;
+    let mut pod_job = pod_job_custom("alpine:3.14", "sleep 5", &NAMESPACE_LOOKUP_READ_ONLY)?;
+    pod_job.hash = "bad?hash".into();
+    let responses = client.submit_pod_jobs(vec![pod_job.into()]).await;
+    assert!(
+        responses.len() == 1,
+        "Client received an unexpected number of pod job request responses."
+    );
+    assert!(
+        responses[0].contains("Agent encountered a communication error."),
+        "Client did not experience expected publish error."
+    );
+    Ok(())
 }

--- a/tests/extra/python/agent_test.py
+++ b/tests/extra/python/agent_test.py
@@ -31,7 +31,7 @@ async def verify(group, pod_job_count):
         with session.declare_subscriber(
             f"group/{group}/success/pod_job/**", count
         ) as subscriber:
-            await asyncio.sleep(10)
+            await asyncio.sleep(20)
 
     if counter != pod_job_count:
         raise Exception(f"Unexpected successful pod job count: {counter}.")

--- a/tests/extra/python/agent_test.py
+++ b/tests/extra/python/agent_test.py
@@ -12,6 +12,7 @@ from orcapod import (
     Agent,
     AgentClient,
     LocalDockerOrchestrator,
+    LocalFileStore,
     PodJob,
     Uri,
     Pod,
@@ -38,7 +39,12 @@ async def verify(group, pod_job_count):
 
 async def main(client, agent, test_dir, namespace_lookup, pod_jobs):
     watcher = asyncio.create_task(client.watch(key_expr="**"))
-    worker = asyncio.create_task(agent.start(namespace_lookup=namespace_lookup))
+    worker = asyncio.create_task(
+        agent.start(
+            namespace_lookup=namespace_lookup,
+            available_store=LocalFileStore(directory=f"{test_dir}/store"),
+        ),
+    )
     await asyncio.sleep(5)  # ensure service ready
 
     try:

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -18,7 +18,6 @@ use std::{
     collections::HashMap,
     fs::{self, File},
     hash::RandomState,
-    iter::repeat_with,
     path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::{Arc, LazyLock},
@@ -143,42 +142,57 @@ pub fn pod_result_style(
     )
 }
 
+pub fn pod_job_custom(
+    image_reference: &str,
+    command: &str,
+    namespace_lookup: &HashMap<String, PathBuf, RandomState>,
+) -> Result<PodJob> {
+    PodJob::new(
+        None,
+        Pod::new(
+            None,
+            image_reference.into(),
+            command.into(),
+            HashMap::new(),
+            PathBuf::from("/tmp/output"),
+            HashMap::new(),
+            "https://github.com/place/holder".to_owned(),
+            0.1,          // 100 millicores as frac cores
+            10_u64 << 20, // 10 MiB in bytes
+            None,
+        )?
+        .into(),
+        HashMap::new(),
+        URI {
+            namespace: "default".to_owned(),
+            path: PathBuf::from("."),
+        },
+        1.0,          // 1000 millicores as frac cores
+        10_u64 << 20, // 2GiB in bytes, KiB=<<10, MiB=<<20, GiB=<<30
+        None,
+        namespace_lookup,
+    )
+}
+
 pub fn pod_jobs_stresser(
     image_reference: &str,
     run_duration_secs: u16,
-    count: usize,
+    success_count: usize,
+    error_count: usize,
 ) -> Result<Vec<Arc<PodJob>>> {
-    repeat_with(|| {
-        Ok(Arc::new(PodJob::new(
-            None,
-            Pod::new(
-                None,
-                image_reference.into(),
-                format!(
-                    "stress-ng --cpu 1 --cpu-load 100 --timeout {run_duration_secs} --metrics-brief"
-                ),
-                HashMap::new(),
-                PathBuf::from("/tmp/output"),
-                HashMap::new(),
-                "https://github.com/user/simple".to_owned(),
-                0.1,          // 100 millicores as frac cores
-                10_u64 << 20, // 10 MiB in bytes
-                None,
-            )?
-            .into(),
-            HashMap::new(),
-            URI {
-                namespace: "default".to_owned(),
-                path: PathBuf::from("."),
-            },
-            1.0,          // 1000 millicores as frac cores
-            10_u64 << 20, // 2GiB in bytes, KiB=<<10, MiB=<<20, GiB=<<30
-            None,
-            &NAMESPACE_LOOKUP_READ_ONLY,
-        )?))
-    })
-    .take(count)
-    .collect::<Result<Vec<_>>>()
+    (1..=(success_count + error_count))
+        .map(|i| {
+            if i <= success_count {
+                return Ok(pod_job_custom(
+                    image_reference,
+                    &format!("stress-ng --cpu 1 --cpu-load 100 --timeout {run_duration_secs} --metrics-brief"),
+                    &NAMESPACE_LOOKUP_READ_ONLY,
+                )?
+                .into());
+            }
+            Ok(pod_job_custom(image_reference, "sleep crash", &NAMESPACE_LOOKUP_READ_ONLY)?.into())
+        })
+        .collect::<Result<Vec<_>>>()
 }
 
 pub fn container_image_style(binary_location: impl AsRef<Path>) -> Result<TestContainerImage> {

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -18,9 +18,10 @@ use std::{
     collections::HashMap,
     fs::{self, File},
     hash::RandomState,
+    iter::repeat_with,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    sync::LazyLock,
+    sync::{Arc, LazyLock},
 };
 use tempfile::TempDir;
 
@@ -140,6 +141,44 @@ pub fn pod_result_style(
         1_737_922_307,
         1_737_925_907,
     )
+}
+
+pub fn pod_jobs_stresser(
+    image_reference: &str,
+    run_duration_secs: u16,
+    count: usize,
+) -> Result<Vec<Arc<PodJob>>> {
+    repeat_with(|| {
+        Ok(Arc::new(PodJob::new(
+            None,
+            Pod::new(
+                None,
+                image_reference.into(),
+                format!(
+                    "stress-ng --cpu 1 --cpu-load 100 --timeout {run_duration_secs} --metrics-brief"
+                ),
+                HashMap::new(),
+                PathBuf::from("/tmp/output"),
+                HashMap::new(),
+                "https://github.com/user/simple".to_owned(),
+                0.1,          // 100 millicores as frac cores
+                10_u64 << 20, // 10 MiB in bytes
+                None,
+            )?
+            .into(),
+            HashMap::new(),
+            URI {
+                namespace: "default".to_owned(),
+                path: PathBuf::from("."),
+            },
+            1.0,          // 1000 millicores as frac cores
+            10_u64 << 20, // 2GiB in bytes, KiB=<<10, MiB=<<20, GiB=<<30
+            None,
+            &NAMESPACE_LOOKUP_READ_ONLY,
+        )?))
+    })
+    .take(count)
+    .collect::<Result<Vec<_>>>()
 }
 
 pub fn container_image_style(binary_location: impl AsRef<Path>) -> Result<TestContainerImage> {

--- a/tests/orchestrator.rs
+++ b/tests/orchestrator.rs
@@ -129,6 +129,7 @@ fn remote_container_image_basic() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[expect(clippy::use_debug, reason = "Useful in debugging from CI.")]
 async fn verify_pod_result_not_running() -> Result<()> {
     let results = join_all(
         pod_jobs_stresser(

--- a/tests/orchestrator.rs
+++ b/tests/orchestrator.rs
@@ -36,6 +36,7 @@ where
         orchestrator
             .list_blocking()?
             .iter()
+            .filter(|container| container.pod_job == pod_run.pod_job)
             .map(|run| Ok(orchestrator.get_info_blocking(run)?.command))
             .collect::<Result<Vec<_>>>()?,
         vec![expected_command.clone()],
@@ -52,6 +53,7 @@ where
         orchestrator
             .list_blocking()?
             .iter()
+            .filter(|container| container.pod_job == pod_run.pod_job)
             .map(|run| Ok(orchestrator.get_info_blocking(run)?.command))
             .collect::<Result<Vec<_>>>()?,
         vec![expected_command],
@@ -67,7 +69,10 @@ where
     // test delete
     orchestrator.delete_blocking(&pod_run)?;
     assert!(
-        orchestrator.list_blocking()?.is_empty(),
+        !orchestrator
+            .list_blocking()?
+            .iter()
+            .any(|container| container.pod_job == pod_run.pod_job),
         "Unexpected container remains."
     );
     // try getting info of a purged pod run

--- a/tests/orchestrator.rs
+++ b/tests/orchestrator.rs
@@ -2,8 +2,8 @@
 
 pub mod fixture;
 use fixture::{
-    NAMESPACE_LOOKUP_READ_ONLY, TestContainerImage, TestDirs, container_image_style, pod_job_style,
-    pod_jobs_stresser,
+    NAMESPACE_LOOKUP_READ_ONLY, TestContainerImage, TestDirs, container_image_style,
+    pod_job_custom, pod_job_style, pod_jobs_stresser,
 };
 use futures_util::future::join_all;
 use orcapod::uniffi::{
@@ -11,7 +11,7 @@ use orcapod::uniffi::{
     model::URI,
     orchestrator::{ImageKind, Orchestrator as _, PodRun, Status, docker::LocalDockerOrchestrator},
 };
-use std::{collections::HashMap, ops::Deref as _, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf};
 
 fn basic_test<T>(start: T) -> Result<()>
 where
@@ -113,19 +113,28 @@ fn offline_container_image_basic() -> Result<()> {
 #[test]
 fn remote_container_image_basic() -> Result<()> {
     basic_test(|namespace_lookup, orchestrator| {
-        let mut pod_job = pod_job_style(namespace_lookup)?;
-        let mut pod = pod_job.pod.deref().clone();
-        pod.image = "alpine:3.14".to_owned();
-        pod.command = "sleep 5".to_owned();
-        pod.input_spec = HashMap::new();
-        pod_job.pod = Arc::new(pod);
-        pod_job.input_packet = HashMap::new();
+        let pod_job = pod_job_custom("alpine:3.14", "sleep 5", namespace_lookup)?;
         Ok((
             orchestrator.start_blocking(namespace_lookup, &pod_job)?,
             pod_job.pod.command.clone(),
             None,
         ))
     })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn remote_container_image_failed() -> Result<()> {
+    let orch = LocalDockerOrchestrator::new()?;
+    let pod_job = pod_job_custom("alpine:3.14", "sleep crash", &NAMESPACE_LOOKUP_READ_ONLY)?;
+    let pod_run = orch.start(&NAMESPACE_LOOKUP_READ_ONLY, &pod_job).await?;
+    let pod_result = orch.get_result(&pod_run).await?;
+    orch.delete(&pod_run).await?;
+
+    assert!(
+        matches!(pod_result.status, Status::Failed(1)),
+        "Expected to fail but did not."
+    );
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -136,6 +145,7 @@ async fn verify_pod_result_not_running() -> Result<()> {
             "ghcr.io/colinianking/stress-ng:e2f96874f951a72c1c83ff49098661f0e013ac40",
             5,
             16,
+            0,
         )?
         .iter()
         .map(|pod_job| async move {

--- a/tests/orchestrator.rs
+++ b/tests/orchestrator.rs
@@ -1,9 +1,13 @@
 #![expect(missing_docs, clippy::panic_in_result_fn, reason = "OK in tests.")]
 
 pub mod fixture;
-use fixture::{TestContainerImage, TestDirs, container_image_style, pod_job_style};
+use fixture::{
+    NAMESPACE_LOOKUP_READ_ONLY, TestContainerImage, TestDirs, container_image_style, pod_job_style,
+    pod_jobs_stresser,
+};
+use futures_util::future::join_all;
 use orcapod::uniffi::{
-    error::Result,
+    error::{OrcaError, Result},
     model::URI,
     orchestrator::{ImageKind, Orchestrator as _, PodRun, Status, docker::LocalDockerOrchestrator},
 };
@@ -117,4 +121,37 @@ fn remote_container_image_basic() -> Result<()> {
             None,
         ))
     })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn verify_pod_result_not_running() -> Result<()> {
+    let results = join_all(
+        pod_jobs_stresser(
+            "ghcr.io/colinianking/stress-ng:e2f96874f951a72c1c83ff49098661f0e013ac40",
+            5,
+            16,
+        )?
+        .iter()
+        .map(|pod_job| async move {
+            let orch = LocalDockerOrchestrator::new()?;
+            let pod_run = orch.start(&NAMESPACE_LOOKUP_READ_ONLY, pod_job).await?;
+            let pod_result = orch.get_result(&pod_run).await?;
+            orch.delete(&pod_run).await?;
+            Ok::<_, OrcaError>(pod_result)
+        }),
+    )
+    .await;
+
+    let statuses = results
+        .into_iter()
+        .map(|result| Ok(result?.status))
+        .filter(|status| !matches!(status, Ok(Status::Completed)))
+        .collect::<Result<Vec<_>>>()?;
+
+    println!("statuses: {statuses:?}");
+    assert!(
+        statuses.is_empty(),
+        "Some pod results returned in a status other than `Completed`."
+    );
+    Ok(())
 }


### PR DESCRIPTION
Depends on #91 

- Add `available_store` option to `agent.start(..)` which will save pod results as they become available.
- Use a dedicated `Response` enum as opposed to casting async `Ok(())` responses to string over FFI boundary.
- Fix bug where `orch.get_result(...)` sometimes returned a `PodRun` with `Status::Running`.
- Fix bug where `orch.get_result(..)` would throw an error if a `PodRun` was unsuccessful instead of producing a `PodResult`  i.e. storing failed pod results can improve the user debugging experience.
- Fix bug related to some collisions between agent and orchestrator tests.
- Include `ContainerStateStatusEnum::REMOVING` when determining how to cast to `uniffi::orchestrator::Status`.

Known places for improvement. Propose we file the following into separate issues:
- Similar to #91, `agent.start(..)` adds another hard coded `Arc<LocalFileStore>` as opposed to the intended `Arc<dyn Store>`. That PR has a more detailed description and the reasoning here is the same. Once we identify a good solution, both can be fixed together.