### PR TITLE
Make zenoh key expression structure easier to maintain

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install code coverage
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run syntax and style tests
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --no-default-features --features=test --all-targets -- -D warnings
       - name: Run format test
         run: cargo fmt --check
       - name: Run integration tests w/ coverage report
@@ -31,6 +31,8 @@ jobs:
         run: |
           mkdir -p tests/.tmp
           cargo llvm-cov \
+            --no-default-features \
+            --features=test \
             --ignore-filename-regex "bin/.*|lib\.rs" \
             --cobertura \
             --output-path target/llvm-cov-target/cobertura.xml \

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,8 @@
             "cargo": {
                 "args": [
                     "test",
+                    "--no-default-features",
+                    "--features=test",
                     "--no-run",
                     "--package=orcapod",
                     "--test",
@@ -31,6 +33,8 @@
             "cargo": {
                 "args": [
                     "test",
+                    "--no-default-features",
+                    "--features=test",
                     "--no-run",
                     "--package=orcapod",
                     "--test",
@@ -53,6 +57,8 @@
             "cargo": {
                 "args": [
                     "test",
+                    "--no-default-features",
+                    "--features=test",
                     "--no-run",
                     "--lib",
                     "--package=orcapod"
@@ -86,6 +92,8 @@
             "cargo": {
                 "args": [
                     "test",
+                    "--no-default-features",
+                    "--features=test",
                     "--no-run",
                     "--package=orcapod",
                     "--bin=exe_file_stem"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+    "[markdown]": {
+        "editor.defaultFormatter": null
+    },
     "editor.formatOnPaste": false,
     "editor.formatOnSave": true,
     "editor.rulers": [
@@ -6,12 +9,13 @@
     ],
     "files.autoSave": "off",
     "files.insertFinalNewline": true,
-    "[markdown]": {
-        "editor.defaultFormatter": null
-    },
     "gitlens.showWelcomeOnInstall": false,
     "gitlens.showWhatsNewAfterUpgrades": false,
     "lldb.consoleMode": "evaluate",
+    "rust-analyzer.cargo.features": [
+        "test"
+    ],
+    "rust-analyzer.cargo.noDefaultFeatures": true,
     "rust-analyzer.check.command": "clippy",
     "rust-analyzer.runnables.extraTestBinaryArgs": [
         "--nocapture"
@@ -22,10 +26,10 @@
     ],
     "jupyter.kernels.excludePythonEnvironments": [
         "/bin/python3",
-        "/usr/bin/python3",
+        "/usr/bin/python3"
     ],
     "notebook.formatOnSave.enabled": true,
     "notebook.output.scrolling": true,
     "python.defaultInterpreterPath": "~/.local/share/base/bin/python3",
-    "python.terminal.activateEnvironment": false,
+    "python.terminal.activateEnvironment": false
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ categories = [
 license = "MIT license"
 edition = "2024"
 
+[features]
+default = []
+test = []
+
 [lib]
 crate-type = ["rlib", "cdylib"]
 
@@ -108,6 +112,7 @@ restriction = "deny"
 style = "deny"
 suspicious = "deny"
 
+allow_attributes = { level = "allow", priority = 127 }                 # Useful when suppressing warnings is also desired.
 arbitrary_source_item_ordering = { level = "allow", priority = 127 }   # allow arbitrary ordering to keep relevant code nearby
 arithmetic_side_effects = { level = "allow", priority = 127 }          # allow arithmetic for convenience though it could overflow
 as_conversions = { level = "allow", priority = 127 }                   # allow casting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ heck = "0.5.0"
 hex = "0.4.3"
 # hashmaps that preserve insertion order
 indexmap = { version = "2.9.0", features = ["serde"] }
+# utilities for iterables
+itertools = "0.14.0"
 # random name generator
 names = "0.14.0"
 # graph algorithms

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ cargo modules dependencies --lib --no-uses --no-fns --focus-on "orcapod::uniffi:
 
 ## Git Worktrees
 
+Update your git to at least version 2.48 since that is when the `--relative-paths` option was added to git worktree. That option makes it compatible with launching using VSCode DevContainers.
+
 ```bash
 git worktree add /path/to/new/dir-name branch-name --relative-paths # create
 git worktree remove dir-name # delete

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 ```bash
 #!/bin/bash
 set -e  # fail early on non-zero exit
-cargo clippy --all-targets -- -D warnings  # Rust syntax and style tests
+cargo clippy --no-default-features --features=test --all-targets -- -D warnings  # Rust syntax and style tests
 cargo fmt --check  # Rust formatting test
-cargo llvm-cov --no-clean --ignore-filename-regex "bin/.*|lib\.rs" -- --nocapture  # Rust integration tests w/ stdout coverage summary
-cargo llvm-cov --no-clean --ignore-filename-regex "bin/.*|lib\.rs" --html -- --nocapture  # Rust integration tests w/ HTML coverage report (target/llvm-cov/html/index.html)
-cargo llvm-cov --no-clean --ignore-filename-regex "bin/.*|lib\.rs" --codecov --output-path target/llvm-cov-target/codecov.json -- --nocapture  # Rust integration tests w/ codecov coverage report
-cargo llvm-cov --no-clean --ignore-filename-regex "bin/.*|lib\.rs" --cobertura --output-path target/llvm-cov-target/cobertura.xml -- --nocapture  # Rust integration tests w/ cobertura coverage report
-. ~/.local/share/base/bin/activate && maturin develop --uv && export RUST_BACKTRACE=1 && python tests/extra/python/smoke_test.py -- tests/.tmp && python tests/extra/python/agent_test.py # Python integration tests
+cargo llvm-cov --no-clean --no-default-features --features=test --ignore-filename-regex "bin/.*|lib\.rs" -- --nocapture  # Rust integration tests w/ stdout coverage summary
+cargo llvm-cov --no-clean --no-default-features --features=test --ignore-filename-regex "bin/.*|lib\.rs" --html -- --nocapture  # Rust integration tests w/ HTML coverage report (target/llvm-cov/html/index.html)
+cargo llvm-cov --no-clean --no-default-features --features=test --ignore-filename-regex "bin/.*|lib\.rs" --codecov --output-path target/llvm-cov-target/codecov.json -- --nocapture  # Rust integration tests w/ codecov coverage report
+cargo llvm-cov --no-clean --no-default-features --features=test --ignore-filename-regex "bin/.*|lib\.rs" --cobertura --output-path target/llvm-cov-target/cobertura.xml -- --nocapture  # Rust integration tests w/ cobertura coverage report
+. ~/.local/share/base/bin/activate && maturin develop --uv && export RUST_BACKTRACE=1 && python tests/extra/python/smoke_test.py -- tests/.tmp && python tests/extra/python/agent_test.py -- tests/.tmp # Python integration tests
 ```
 
 ## Docs

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ cargo modules dependencies --lib --no-uses --no-fns --focus-on "orcapod::uniffi:
 cargo modules dependencies --lib --no-uses --no-fns --focus-on "orcapod::uniffi::{model::{Pod,PodJob,PodResult},store::filestore::LocalFileStore,orchestrator::{PodRun,docker::LocalDockerOrchestrator}}" --layout dot | dot -T svg > docs/images/orcapod_diagram.svg # orcapod diagram as SVG
 ```
 
+## Git Worktrees
+
+```bash
+git worktree add /path/to/new/dir-name branch-name --relative-paths # create
+git worktree remove dir-name # delete
+```
+
 ## Project Management
 
 Progress is tracked under GH project [orcapod](https://github.com/orgs/walkerlab/projects/2).

--- a/cspell.json
+++ b/cspell.json
@@ -78,7 +78,8 @@
         "strsim",
         "getrandom",
         "wasi",
-        "patchelf"
+        "patchelf",
+        "itertools"
     ],
     "useGitignore": false,
     "ignorePaths": [

--- a/src/core/crypto.rs
+++ b/src/core/crypto.rs
@@ -26,7 +26,7 @@ use std::{
     clippy::indexing_slicing,
     reason = "Reading less than 0 is impossible."
 )]
-pub(crate) fn hash_stream(stream: &mut impl Read) -> Result<String> {
+pub fn hash_stream(stream: &mut impl Read) -> Result<String> {
     const BUFFER_SIZE: usize = 8 << 10; // 8KB chunks to match with page size typically found
     let mut hash = Sha256::new();
 
@@ -88,7 +88,7 @@ pub fn hash_dir(dirpath: impl AsRef<Path>) -> Result<String> {
 /// # Errors
 ///
 /// Will return error if hashing fails on file or directory.
-pub(crate) fn hash_blob(
+pub fn hash_blob(
     namespace_lookup: &HashMap<String, PathBuf, RandomState>,
     blob: &Blob,
 ) -> Result<Blob> {
@@ -102,7 +102,7 @@ pub(crate) fn hash_blob(
     })
 }
 
-pub(crate) fn make_random_hash() -> String {
+pub fn make_random_hash() -> String {
     let mut bytes = [0; 32];
     rand::rng().fill_bytes(&mut bytes);
     hex::encode(bytes)

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -122,18 +122,9 @@ impl fmt::Debug for OrcaError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self.kind {
             Kind::AgentCommunicationFailure { backtrace, .. }
-            | Kind::EmptyResponseWhenLoadingContainerAltImage { backtrace, .. }
-            | Kind::GeneratedNamesOverflow { backtrace, .. }
             | Kind::IncompletePacket { backtrace, .. }
             | Kind::InvalidFilepath { backtrace, .. }
-            | Kind::InvalidPodResultTerminatedDatetime { backtrace, .. }
-            | Kind::KeyMissing { backtrace, .. }
-            | Kind::NoAnnotationFound { backtrace, .. }
-            | Kind::NoContainerNames { backtrace, .. }
-            | Kind::NoFileName { backtrace, .. }
-            | Kind::NoMatchingPodRun { backtrace, .. }
-            | Kind::NoRemainingServices { backtrace, .. }
-            | Kind::NoTagFoundInContainerAltImage { backtrace, .. }
+            | Kind::MissingInfo { backtrace, .. }
             | Kind::BollardError { backtrace, .. }
             | Kind::ChronoParseError { backtrace, .. }
             | Kind::DOTError { backtrace, .. }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,11 +1,38 @@
-/// State change verification via cryptographic utilities.
-pub mod crypto;
+macro_rules! inner_attr_to_each {
+    { #!$attr:tt $($it:item)* } => {
+        $(
+            #$attr
+            $it
+        )*
+    }
+}
+
 pub(crate) mod error;
 pub(crate) mod graph;
-/// Components of the data model.
-pub mod model;
-pub(crate) mod orchestrator;
 pub(crate) mod pipeline;
 pub(crate) mod store;
 pub(crate) mod util;
 pub(crate) mod validation;
+
+inner_attr_to_each! {
+    #![cfg(feature = "default")]
+    pub(crate) mod crypto;
+    pub(crate) mod model;
+    pub(crate) mod orchestrator;
+}
+
+#[cfg(feature = "test")]
+inner_attr_to_each! {
+    #![cfg_attr(
+        feature = "test",
+        allow(
+            missing_docs,
+            clippy::missing_errors_doc,
+            clippy::missing_panics_doc,
+            reason = "Documentation not necessary since private API.",
+        ),
+    )]
+    pub mod crypto;
+    pub mod model;
+    pub mod orchestrator;
+}

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize as _, Deserializer, Serialize, Serializer};
 use serde_yaml::{self, Value};
 use std::{
     collections::{BTreeMap, HashMap},
+    hash::BuildHasher,
     result,
     sync::Arc,
 };
@@ -38,8 +39,8 @@ pub fn to_yaml<T: Serialize>(instance: &T) -> Result<String> {
     Ok(yaml)
 }
 
-pub(crate) fn serialize_hashmap<S, K: Ord + Serialize, V: Serialize>(
-    map: &HashMap<K, V>,
+pub fn serialize_hashmap<S, K: Ord + Serialize, V: Serialize, BH: BuildHasher>(
+    map: &HashMap<K, V, BH>,
     serializer: S,
 ) -> result::Result<S::Ok, S::Error>
 where
@@ -49,9 +50,9 @@ where
     sorted.serialize(serializer)
 }
 
-#[expect(clippy::ref_option, reason = "Serde requires this signature.")]
-pub(crate) fn serialize_hashmap_option<S, K: Ord + Serialize, V: Serialize>(
-    map_option: &Option<HashMap<K, V>>,
+#[allow(clippy::ref_option, reason = "Serde requires this signature.")]
+pub fn serialize_hashmap_option<S, K: Ord + Serialize, V: Serialize, BH: BuildHasher>(
+    map_option: &Option<HashMap<K, V, BH>>,
     serializer: S,
 ) -> result::Result<S::Ok, S::Error>
 where
@@ -63,11 +64,8 @@ where
     sorted.serialize(serializer)
 }
 
-#[expect(
-    clippy::expect_used,
-    reason = "Function signature required by serde API."
-)]
-pub(crate) fn deserialize_pod<'de, D>(deserializer: D) -> result::Result<Arc<Pod>, D::Error>
+#[expect(clippy::expect_used, reason = "Serde requires this signature.")]
+pub fn deserialize_pod<'de, D>(deserializer: D) -> result::Result<Arc<Pod>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -89,11 +87,8 @@ where
     )
 }
 
-#[expect(
-    clippy::expect_used,
-    reason = "Function signature required by serde API."
-)]
-pub(crate) fn deserialize_pod_job<'de, D>(deserializer: D) -> result::Result<Arc<PodJob>, D::Error>
+#[expect(clippy::expect_used, reason = "Serde requires this signature.")]
+pub fn deserialize_pod_job<'de, D>(deserializer: D) -> result::Result<Arc<PodJob>, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/src/core/orchestrator/agent.rs
+++ b/src/core/orchestrator/agent.rs
@@ -2,15 +2,17 @@ use crate::uniffi::{
     error::{OrcaError, Result, selector},
     orchestrator::agent::{Agent, AgentClient},
 };
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use futures_util::future::FutureExt as _;
-use regex::Regex;
+use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt as _, ResultExt as _};
 use std::{
-    collections::HashMap,
+    borrow::ToOwned,
+    collections::{BTreeMap, HashMap},
+    fmt::Write as _,
     path::PathBuf,
-    sync::{Arc, LazyLock},
+    sync::Arc,
 };
 use tokio::{
     sync::mpsc::{self, error::SendError},
@@ -18,56 +20,59 @@ use tokio::{
 };
 use tokio_util::task::TaskTracker;
 
-#[expect(clippy::expect_used, reason = "Valid static regex")]
-static RE_AGENT_KEY_EXPR: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"(?x)
-            ^
-            group/
-                (?<group>[a-z_\-]+)/
-                    (?<action>request|success|failure)/
-                        (?<model_type>[a-z_]+)/
-                            (?<ref>[0-9a-f]+)/
-                                .*?
-                                    host/
-                                        (?<host>[a-z_]+)/
-                                            timestamp/
-                                                (?<timestamp>.*?)
-            $
-            ",
-    )
-    .expect("Invalid PodJob action regex.")
-});
-
-#[expect(
-    dead_code,
-    reason = "Need to be able to initialize to pass metadata as input."
-)]
-#[derive(Debug)]
-pub struct EventMetadata {
-    pub group: String,
-    pub action: String,
-    pub model_type: String,
-    pub r#ref: String,
-    pub host: String,
-    pub timestamp: DateTime<Utc>,
+fn extract_metadata(key_expr: &str) -> HashMap<String, String> {
+    key_expr
+        .split('/')
+        .map(ToOwned::to_owned)
+        .tuples()
+        .collect()
 }
 
 impl AgentClient {
-    pub(crate) async fn publish<T>(&self, topic: &str, payload: &T) -> Result<()>
+    #[expect(
+        clippy::let_underscore_must_use,
+        reason = "write! on a `String` cannot fail. https://rust-lang.github.io/rust-clippy/master/index.html#format_collect"
+    )]
+    pub(crate) fn make_key_expr(
+        &self,
+        is_subscriber: bool,
+        topic: &str,
+        mut metadata: BTreeMap<&str, String>,
+    ) -> String {
+        metadata.insert("group", self.group.clone());
+        metadata.insert("topic", topic.to_owned());
+
+        let delimiter = if is_subscriber {
+            "**/".to_owned()
+        } else {
+            metadata.insert("host", self.host.clone());
+            metadata.insert("timestamp", Utc::now().to_rfc3339());
+            String::new()
+        };
+
+        metadata
+            .iter()
+            .fold(delimiter.clone(), |mut key_expr, (key, value)| {
+                let _ = write!(key_expr, "{key}/{value}/{delimiter}");
+                key_expr
+            })
+            .trim_end_matches('/')
+            .to_owned()
+    }
+
+    pub(crate) async fn publish<T>(
+        &self,
+        topic: &str,
+        metadata: BTreeMap<&str, String>,
+        payload: &T,
+    ) -> Result<()>
     where
         T: Serialize + Sync + ?Sized,
     {
         Ok(self
             .session
             .put(
-                format!(
-                    "group/{}/{}/host/{}/timestamp/{}",
-                    self.group,
-                    topic,
-                    self.host,
-                    Utc::now().to_rfc3339()
-                ),
+                self.make_key_expr(false, topic, metadata),
                 &serde_json::to_vec(payload)?,
             )
             .await
@@ -79,7 +84,7 @@ impl AgentClient {
     ///
     /// Will fail if there is an issue sending the message.
     pub(crate) async fn log(&self, message: &str) -> Result<()> {
-        self.publish("log", message).await
+        self.publish("log", BTreeMap::new(), message).await
     }
 }
 
@@ -97,14 +102,15 @@ pub async fn start_service<
     ResponseR, // output to the function for responses
 >(
     agent: Arc<Agent>,
-    request_key_expr: String,
+    request_topic: &str,
+    request_metadata: BTreeMap<&'static str, String>,
     namespace_lookup: HashMap<String, PathBuf>,
     request_task: RequestF,
     response_task: ResponseF,
 ) -> Result<()>
 where
     RequestI: for<'serde> Deserialize<'serde> + Send + 'static,
-    RequestF: FnOnce(Arc<Agent>, HashMap<String, PathBuf>, EventMetadata, RequestI) -> RequestR
+    RequestF: FnOnce(Arc<Agent>, HashMap<String, PathBuf>, HashMap<String, String>, RequestI) -> RequestR
         + Clone
         + Send
         + 'static,
@@ -115,38 +121,33 @@ where
 {
     agent
         .client
-        .log(&format!("Started `{request_key_expr}` service."))
+        .log(&format!(
+            "Started `{request_topic}` service for {request_metadata:?}."
+        ))
         .await?;
     let (response_tx, mut response_rx) = mpsc::channel(100);
 
     let mut services = JoinSet::new();
     services.spawn({
         let inner_agent = Arc::clone(&agent);
+        let inner_request_topic = request_topic.to_owned();
         async move {
             let tasks = TaskTracker::new();
             let subscriber = inner_agent
                 .client
                 .session
-                .declare_subscriber(format!(
-                    "group/{}/{}",
-                    inner_agent.client.group, request_key_expr
+                .declare_subscriber(inner_agent.client.make_key_expr(
+                    true,
+                    &inner_request_topic,
+                    request_metadata,
                 ))
                 .await
                 .context(selector::AgentCommunicationFailure {})?;
             while let Ok(sample) = subscriber.recv_async().await {
-                if let (Ok(input), Some(metadata)) = (
-                    serde_json::from_slice::<RequestI>(&sample.payload().to_bytes()),
-                    RE_AGENT_KEY_EXPR.captures(sample.key_expr().as_str()),
-                ) {
+                if let Ok(input) = serde_json::from_slice::<RequestI>(&sample.payload().to_bytes())
+                {
                     let inner_response_tx = response_tx.clone();
-                    let event_metadata = EventMetadata {
-                        group: metadata["group"].to_string(),
-                        action: metadata["action"].to_string(),
-                        model_type: metadata["model_type"].to_string(),
-                        r#ref: metadata["ref"].to_string(),
-                        host: metadata["host"].to_string(),
-                        timestamp: DateTime::parse_from_rfc3339(&metadata["timestamp"])?.into(),
-                    };
+                    let event_metadata = extract_metadata(sample.key_expr().as_str());
                     tasks.spawn({
                         let inner_request_task = request_task.clone();
                         let inner_inner_agent = Arc::clone(&inner_agent);

--- a/src/core/orchestrator/agent.rs
+++ b/src/core/orchestrator/agent.rs
@@ -2,7 +2,7 @@ use crate::uniffi::{
     error::{OrcaError, Result, selector},
     orchestrator::agent::{Agent, AgentClient},
 };
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use futures_util::future::FutureExt as _;
 use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
@@ -111,7 +111,12 @@ pub async fn start_service<
 ) -> Result<()>
 where
     RequestI: for<'serde> Deserialize<'serde> + Send + 'static,
-    RequestF: FnOnce(Arc<Agent>, HashMap<String, PathBuf>, HashMap<String, String>, RequestI) -> RequestR
+    RequestF: FnOnce(
+            Arc<Agent>,
+            HashMap<String, PathBuf>,
+            (DateTime<Utc>, HashMap<String, String>),
+            RequestI,
+        ) -> RequestR
         + Clone
         + Send
         + 'static,
@@ -144,44 +149,54 @@ where
                 ))
                 .await
                 .context(selector::AgentCommunicationFailure {})?;
-            while let Ok(sample) = subscriber.recv_async().await {
-                if let Ok(input) = serde_json::from_slice::<RequestI>(&sample.payload().to_bytes())
-                {
-                    let inner_response_tx = response_tx.clone();
-                    let event_metadata = extract_metadata(sample.key_expr().as_str());
-                    tasks.spawn({
-                        let inner_request_task = request_task.clone();
-                        let inner_inner_agent = Arc::clone(&inner_agent);
-                        let inner_namespace_lookup = namespace_lookup.clone();
-                        async move {
-                            inner_request_task(
-                                inner_inner_agent,
-                                inner_namespace_lookup,
-                                event_metadata,
-                                input,
-                            )
-                            .then(move |response| async move {
-                                let _: Result<(), SendError<Result<ResponseI>>> =
-                                    inner_response_tx.send(response).await;
-                                Ok::<_, OrcaError>(())
-                            })
-                            .await
-                        }
-                    });
-                }
+            loop {
+                let sample = subscriber
+                    .recv_async()
+                    .await
+                    .context(selector::AgentCommunicationFailure {})?;
+                let input = serde_json::from_slice::<RequestI>(&sample.payload().to_bytes())?;
+                let inner_response_tx = response_tx.clone();
+                let mut event_metadata = extract_metadata(sample.key_expr().as_str());
+                let timestamp =
+                    event_metadata
+                        .remove("timestamp")
+                        .context(selector::MissingInfo {
+                            details: "timestamp",
+                        })?;
+                let event_timestamp =
+                    DateTime::<Utc>::from(DateTime::parse_from_rfc3339(&timestamp)?);
+                tasks.spawn({
+                    let inner_request_task = request_task.clone();
+                    let inner_inner_agent = Arc::clone(&inner_agent);
+                    let inner_namespace_lookup = namespace_lookup.clone();
+                    async move {
+                        inner_request_task(
+                            inner_inner_agent,
+                            inner_namespace_lookup,
+                            (event_timestamp, event_metadata),
+                            input,
+                        )
+                        .then(move |response| async move {
+                            let _: Result<(), SendError<Result<ResponseI>>> =
+                                inner_response_tx.send(response).await;
+                            Ok::<_, OrcaError>(())
+                        })
+                        .await
+                    }
+                });
             }
-            Ok(())
         }
     });
     services.spawn(async move {
-        while let Some(response) = response_rx.recv().await {
+        loop {
+            let response = response_rx.recv().await.context(selector::MissingInfo {
+                details: "channel empty or closed",
+            })?;
             response_task(Arc::clone(&agent.client), response?).await?;
         }
-        Ok(())
     });
 
-    services
-        .join_next()
-        .await
-        .context(selector::NoRemainingServices {})??
+    services.join_next().await.context(selector::MissingInfo {
+        details: "no available services",
+    })??
 }

--- a/src/core/orchestrator/agent.rs
+++ b/src/core/orchestrator/agent.rs
@@ -11,6 +11,7 @@ use std::{
     borrow::ToOwned,
     collections::{BTreeMap, HashMap},
     fmt::Write as _,
+    hash::RandomState,
     path::PathBuf,
     sync::Arc,
 };
@@ -20,7 +21,7 @@ use tokio::{
 };
 use tokio_util::task::TaskTracker;
 
-fn extract_metadata(key_expr: &str) -> HashMap<String, String> {
+pub fn extract_metadata(key_expr: &str) -> HashMap<String, String> {
     key_expr
         .split('/')
         .map(ToOwned::to_owned)
@@ -104,7 +105,7 @@ pub async fn start_service<
     agent: Arc<Agent>,
     request_topic: &str,
     request_metadata: BTreeMap<&'static str, String>,
-    namespace_lookup: HashMap<String, PathBuf>,
+    namespace_lookup: HashMap<String, PathBuf, RandomState>,
     request_task: RequestF,
     response_task: ResponseF,
 ) -> Result<()>

--- a/src/core/orchestrator/docker.rs
+++ b/src/core/orchestrator/docker.rs
@@ -79,8 +79,11 @@ impl LocalDockerOrchestrator {
                                 stream_info
                                     .path
                                     .join(blob.location.path.file_name().context(
-                                        selector::NoFileName {
-                                            path: blob.location.path.clone()
+                                        selector::MissingInfo {
+                                            details: format!(
+                                                "file or directory name where path = {}",
+                                                blob.location.path.to_string_lossy()
+                                            ),
                                         }
                                     )?)
                                     .to_string_lossy(),
@@ -115,9 +118,12 @@ impl LocalDockerOrchestrator {
     )> {
         // Prepare configuration
         let (input_binds, output_bind) = Self::prepare_mount_binds(namespace_lookup, pod_job)?;
-        let container_name = Generator::with_naming(Name::Plain)
-            .next()
-            .context(selector::GeneratedNamesOverflow)?;
+        let container_name =
+            Generator::with_naming(Name::Plain)
+                .next()
+                .context(selector::MissingInfo {
+                    details: "unable to generate a random name",
+                })?;
         let labels = HashMap::from([
             ("org.orcapod".to_owned(), "true".to_owned()),
             (
@@ -164,6 +170,7 @@ impl LocalDockerOrchestrator {
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
         clippy::indexing_slicing,
+        clippy::too_many_lines,
         reason = r#"
         - Timestamp and memory should always have a value > 0
         - Container will always have a name with more than 1 character
@@ -186,10 +193,13 @@ impl LocalDockerOrchestrator {
                 .await?
                 .iter()
                 .map(|container_summary| async {
-                    let container_name = &container_summary
-                        .names
-                        .as_ref()
-                        .context(selector::NoContainerNames)?[0][1..];
+                    let container_name =
+                        &container_summary
+                            .names
+                            .as_ref()
+                            .context(selector::MissingInfo {
+                                details: "container name(s)".to_owned(),
+                            })?[0][1..];
                     Ok((
                         container_name.to_owned(),
                         container_summary.clone(),

--- a/src/core/store/filestore.rs
+++ b/src/core/store/filestore.rs
@@ -102,10 +102,11 @@ impl LocalFileStore {
             Self::make_annotation_relpath(name, version),
         ))?
         .next()
-        .context(selector::NoAnnotationFound {
-            class: parse_debug_name(model).to_snake_case(),
-            name: name.to_owned(),
-            version: version.to_owned(),
+        .context(selector::MissingInfo {
+            details: format!(
+                "annotation where class = {}, name = {name}, version = {version}",
+                parse_debug_name(model).to_snake_case()
+            ),
         })?;
         Ok(model_info.hash)
     }

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -31,7 +31,7 @@ where
     Q: ?Sized + hash::Hash + Eq + fmt::Debug,
     K: Borrow<Q> + hash::Hash + Eq,
 {
-    Ok(map.get(key).context(selector::KeyMissing {
-        key: format!("{key:?}"),
+    Ok(map.get(key).context(selector::MissingInfo {
+        details: format!("key = {key:?}"),
     })?)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,10 @@
 //! mind.
 extern crate uniffi as uniffi_external;
 uniffi_external::setup_scaffolding!();
+
+#[cfg(all(feature = "default", feature = "test"))]
+compile_error!(r#"Feature "default" and feature "test" cannot be enabled at the same time."#);
+
 /// Pure Rust source.
 pub mod core;
 /// Exposed CFFI client based on [uniffi](https://crates.io/crates/uniffi).

--- a/src/uniffi/error.rs
+++ b/src/uniffi/error.rs
@@ -30,15 +30,6 @@ pub(crate) enum Kind {
         source: Box<dyn Error + Send + Sync>,
         backtrace: Option<Backtrace>,
     },
-    #[snafu(display(
-        "Received an empty response when attempting to load the alternate container image file: {path:?}."
-    ))]
-    EmptyResponseWhenLoadingContainerAltImage {
-        path: PathBuf,
-        backtrace: Option<Backtrace>,
-    },
-    #[snafu(display("Out of generated random names."))]
-    GeneratedNamesOverflow { backtrace: Option<Backtrace> },
     #[snafu(display("Incomplete {kind} packet. Missing `{missing_keys:?}` keys."))]
     IncompletePacket {
         kind: String,
@@ -51,42 +42,9 @@ pub(crate) enum Kind {
         source: io::Error,
         backtrace: Option<Backtrace>,
     },
-    #[snafu(display(
-        "An invalid datetime was set for pod result for pod job (hash: {pod_job_hash})."
-    ))]
-    InvalidPodResultTerminatedDatetime {
-        pod_job_hash: String,
-        backtrace: Option<Backtrace>,
-    },
-    #[snafu(display("Key '{key}' was not found in map."))]
-    KeyMissing {
-        key: String,
-        backtrace: Option<Backtrace>,
-    },
-    #[snafu(display("No annotation found for `{name}:{version}` {class}."))]
-    NoAnnotationFound {
-        class: String,
-        name: String,
-        version: String,
-        backtrace: Option<Backtrace>,
-    },
-    #[snafu(display("No known container names."))]
-    NoContainerNames { backtrace: Option<Backtrace> },
-    #[snafu(display("Missing file or directory name ({path:?})."))]
-    NoFileName {
-        path: PathBuf,
-        backtrace: Option<Backtrace>,
-    },
-    #[snafu(display("No corresponding pod run found for pod job (hash: {pod_job_hash})."))]
-    NoMatchingPodRun {
-        pod_job_hash: String,
-        backtrace: Option<Backtrace>,
-    },
-    #[snafu(display("All services have completed."))]
-    NoRemainingServices { backtrace: Option<Backtrace> },
-    #[snafu(display("No tags found in provided container alternate image: {path:?}."))]
-    NoTagFoundInContainerAltImage {
-        path: PathBuf,
+    #[snafu(display("Missing info. Details: {details}."))]
+    MissingInfo {
+        details: String,
         backtrace: Option<Backtrace>,
     },
     #[snafu(transparent)]
@@ -146,11 +104,11 @@ pub struct OrcaError {
 #[uniffi::export]
 impl OrcaError {
     /// Returns `true` if the error was caused by an invalid model annotation.
-    pub const fn is_invalid_annotation(&self) -> bool {
-        matches!(self.kind, Kind::NoAnnotationFound { .. })
+    pub fn is_invalid_annotation(&self) -> bool {
+        matches!(&self.kind, Kind::MissingInfo { details, .. } if details.contains("annotation"))
     }
     /// Returns `true` if the error was caused by querying a purged pod run.
-    pub const fn is_purged_pod_run(&self) -> bool {
-        matches!(self.kind, Kind::NoMatchingPodRun { .. })
+    pub fn is_purged_pod_run(&self) -> bool {
+        matches!(&self.kind, Kind::MissingInfo { details, .. } if details.contains("pod run"))
     }
 }

--- a/src/uniffi/orchestrator/agent.rs
+++ b/src/uniffi/orchestrator/agent.rs
@@ -14,7 +14,11 @@ use futures_util::future::join_all;
 use getset::CloneGetters;
 use serde_json::Value;
 use snafu::{OptionExt as _, ResultExt as _};
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::PathBuf,
+    sync::Arc,
+};
 use tokio::task::JoinSet;
 use uniffi;
 use zenoh;
@@ -76,7 +80,14 @@ impl AgentClient {
     pub async fn start_pod_jobs(&self, pod_jobs: Vec<Arc<PodJob>>) -> Vec<Response> {
         join_all(pod_jobs.iter().map(|pod_job| async {
             match self
-                .publish(&format!("request/pod_job/{}", pod_job.hash), pod_job)
+                .publish(
+                    "pod_job",
+                    BTreeMap::from([
+                        ("action", "request".to_owned()),
+                        ("hash", pod_job.hash.clone()),
+                    ]),
+                    pod_job,
+                )
                 .await
             {
                 Ok(()) => Response::Ok,
@@ -150,7 +161,8 @@ impl Agent {
         let mut services = JoinSet::new();
         services.spawn(start_service(
             Arc::new(self.clone()),
-            "request/pod_job/**".to_owned(),
+            "pod_job",
+            BTreeMap::from([("action", "request".to_owned())]),
             namespace_lookup.clone(),
             async |agent, inner_namespace_lookup, _, pod_job| {
                 let pod_run = agent
@@ -167,15 +179,20 @@ impl Agent {
             async |client, pod_result| {
                 client
                     .publish(
-                        &format!(
-                            "{}/pod_job/{}",
-                            match &pod_result.status {
-                                PodStatus::Completed => "success",
-                                PodStatus::Running | PodStatus::Failed(_) | PodStatus::Unset =>
-                                    "failure",
-                            },
-                            pod_result.pod_job.hash
-                        ),
+                        "pod_job",
+                        BTreeMap::from([
+                            (
+                                "action",
+                                match &pod_result.status {
+                                    PodStatus::Completed => "success",
+                                    PodStatus::Running
+                                    | PodStatus::Failed(_)
+                                    | PodStatus::Unset => "failure",
+                                }
+                                .to_owned(),
+                            ),
+                            ("hash", pod_result.pod_job.hash.clone()),
+                        ]),
                         &pod_result,
                     )
                     .await
@@ -184,7 +201,8 @@ impl Agent {
         if let Some(store) = available_store {
             services.spawn(start_service(
                 Arc::new(self.clone()),
-                "success/pod_job/**".to_owned(),
+                "pod_job",
+                BTreeMap::from([("action", "success".to_owned())]),
                 namespace_lookup.clone(),
                 {
                     let inner_store = Arc::clone(&store);
@@ -197,7 +215,8 @@ impl Agent {
             ));
             services.spawn(start_service(
                 Arc::new(self.clone()),
-                "failure/pod_job/**".to_owned(),
+                "pod_job",
+                BTreeMap::from([("action", "failure".to_owned())]),
                 namespace_lookup.clone(),
                 async move |_, _, _, pod_result| {
                     store.save_pod_result(&pod_result)?;

--- a/src/uniffi/orchestrator/agent.rs
+++ b/src/uniffi/orchestrator/agent.rs
@@ -108,11 +108,14 @@ impl AgentClient {
             .declare_subscriber(&key_expr)
             .await
             .context(selector::AgentCommunicationFailure {})?;
-        while let Ok(sample) = subscriber.recv_async().await {
+        loop {
+            let sample = subscriber
+                .recv_async()
+                .await
+                .context(selector::AgentCommunicationFailure {})?;
             let value = serde_json::from_slice::<Value>(&sample.payload().to_bytes())?;
             println!("{}: {value:#}", sample.key_expr().as_str().yellow());
         }
-        Ok(())
     }
 }
 
@@ -225,9 +228,8 @@ impl Agent {
                 async |_, ()| Ok(()),
             ));
         }
-        services
-            .join_next()
-            .await
-            .context(selector::NoRemainingServices {})??
+        services.join_next().await.context(selector::MissingInfo {
+            details: "no available services".to_owned(),
+        })??
     }
 }

--- a/src/uniffi/orchestrator/docker.rs
+++ b/src/uniffi/orchestrator/docker.rs
@@ -109,14 +109,15 @@ impl Orchestrator for LocalDockerOrchestrator {
                 let mut local_image = String::new();
                 while let Some(response) = stream.next().await {
                     local_image = RE_IMAGE_TAG
-                        .captures_iter(&response?.stream.context(
-                            selector::EmptyResponseWhenLoadingContainerAltImage {
-                                path: location.clone(),
-                            },
-                        )?)
+                        .captures_iter(&response?.stream.context(selector::MissingInfo {
+                            details: location.to_string_lossy(),
+                        })?)
                         .find_map(|x| x.name("image").map(|name| name.as_str().to_owned()))
-                        .context(selector::NoTagFoundInContainerAltImage {
-                            path: location.clone(),
+                        .context(selector::MissingInfo {
+                            details: format!(
+                                "container tags in provided container alternate image where path = {}",
+                                location.to_string_lossy()
+                            ),
                         })?;
                 }
                 Self::prepare_container_start_inputs(
@@ -192,8 +193,8 @@ impl Orchestrator for LocalDockerOrchestrator {
             .list_containers(HashMap::from([("label".to_owned(), labels)]))
             .await?
             .next()
-            .context(selector::NoMatchingPodRun {
-                pod_job_hash: pod_run.pod_job.hash.clone(),
+            .context(selector::MissingInfo {
+                details: format!("pod run where pod_job.hash = {}", pod_run.pod_job.hash),
             })?;
         Ok(run_info)
     }
@@ -233,11 +234,12 @@ impl Orchestrator for LocalDockerOrchestrator {
             pod_run.assigned_name.clone(),
             result_info.status,
             result_info.created,
-            result_info
-                .terminated
-                .context(selector::InvalidPodResultTerminatedDatetime {
-                    pod_job_hash: pod_run.pod_job.hash.clone(),
-                })?,
+            result_info.terminated.context(selector::MissingInfo {
+                details: format!(
+                    "terminated where pod_run.assigned_name = {}, pod_run.pod_job.hash = {}",
+                    pod_run.assigned_name, pod_run.pod_job.hash
+                ),
+            })?,
             namespace_lookup,
         )
     }

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -9,15 +9,17 @@
 
 pub mod fixture;
 use fixture::{NAMESPACE_LOOKUP_READ_ONLY, TestDirs, pod_jobs_stresser, pull_image};
-use itertools::Itertools as _;
-use orcapod::uniffi::{
-    error::Result,
-    model::pod::PodResult,
-    orchestrator::{
-        agent::{Agent, AgentClient},
-        docker::LocalDockerOrchestrator,
+use orcapod::{
+    core::orchestrator::agent::extract_metadata,
+    uniffi::{
+        error::Result,
+        model::pod::PodResult,
+        orchestrator::{
+            agent::{Agent, AgentClient},
+            docker::LocalDockerOrchestrator,
+        },
+        store::{ModelID, Store as _, filestore::LocalFileStore},
     },
-    store::{ModelID, Store as _, filestore::LocalFileStore},
 };
 use std::{
     collections::HashMap,
@@ -26,14 +28,6 @@ use std::{
 };
 use tokio::{self, task::JoinSet, time::sleep as async_sleep};
 use zenoh;
-
-fn extract_metadata(key_expr: &str) -> HashMap<String, String> {
-    key_expr
-        .split('/')
-        .map(ToOwned::to_owned)
-        .tuples()
-        .collect()
-}
 
 #[test]
 fn simple() -> Result<()> {

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -9,6 +9,7 @@
 
 pub mod fixture;
 use fixture::{NAMESPACE_LOOKUP_READ_ONLY, TestDirs, pod_jobs_stresser, pull_image};
+use itertools::Itertools as _;
 use orcapod::uniffi::{
     error::Result,
     model::pod::PodResult,
@@ -25,6 +26,14 @@ use std::{
 };
 use tokio::{self, task::JoinSet, time::sleep as async_sleep};
 use zenoh;
+
+fn extract_metadata(key_expr: &str) -> HashMap<String, String> {
+    key_expr
+        .split('/')
+        .map(ToOwned::to_owned)
+        .tuples()
+        .collect()
+}
 
 #[test]
 fn simple() -> Result<()> {
@@ -47,13 +56,8 @@ async fn parallel_four_cores() -> Result<()> {
     // config
     let image_reference = "ghcr.io/colinianking/stress-ng:e2f96874f951a72c1c83ff49098661f0e013ac40";
     pull_image(image_reference)?;
-    let margin_millis = 2000;
+    let margin_millis = 1000;
     let run_duration_secs = 5;
-    let current_timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Current time is earlier than start of epoch (1970-01-01 00:00:00).")
-        .as_millis();
-    println!("current_timestamp: {current_timestamp}");
     let (group, host) = ("agent_parallel-four-cores", "host");
     // api
     let client = AgentClient::new(group.to_owned(), host.to_owned())?;
@@ -64,10 +68,15 @@ async fn parallel_four_cores() -> Result<()> {
     )?;
     // background services
     let mut services = JoinSet::new();
+    services.spawn(async {
+        async_sleep(Duration::from_secs(60)).await;
+        panic!("Test took too long. Killing...");
+    });
     services.spawn({
         let inner_client = client.clone();
         async move { inner_client.watch("**".to_owned()).await }
     });
+    async_sleep(Duration::from_secs(5)).await; // ensure watch is ready
     services.spawn({
         let inner_agent = agent.clone();
         let inner_store = store.clone();
@@ -77,18 +86,25 @@ async fn parallel_four_cores() -> Result<()> {
                 .await
         }
     });
+    async_sleep(Duration::from_secs(5)).await; // ensure services are ready
     services.spawn(async move {
+        let current_timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Current time is earlier than start of epoch (1970-01-01 00:00:00).")
+            .as_millis();
+        println!("current_timestamp: {current_timestamp}");
         let session = zenoh::open(zenoh::Config::default())
             .await
             .expect("Unable to create a zenoh session.");
         let subscriber = session
-            .declare_subscriber(&format!("group/{group}/*/pod_job/**"))
+            .declare_subscriber(&format!("**/group/{group}/**/topic/pod_job/**"))
             .await
             .expect("Unable to create subscriber.");
         let mut success_counter = 0;
         let mut failure_counter = 0;
         while let Ok(sample) = subscriber.recv_async().await {
-            let topic_kind = sample.key_expr().as_str().split('/').collect::<Vec<_>>()[2];
+            let metadata = extract_metadata(sample.key_expr().as_str());
+            let topic_kind = metadata["action"].as_str();
             if ["success", "failure"].contains(&topic_kind) {
                 let pod_result = serde_json::from_slice::<PodResult>(&sample.payload().to_bytes())?;
                 assert!(
@@ -119,10 +135,6 @@ async fn parallel_four_cores() -> Result<()> {
             }
         }
         Ok(())
-    });
-    services.spawn(async {
-        async_sleep(Duration::from_secs(60)).await;
-        panic!("Test took too long. Killing...");
     });
     // submit requests
     client

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -96,7 +96,11 @@ async fn parallel_four_cores() -> Result<()> {
             .expect("Unable to create subscriber.");
         let mut success_counter = 0;
         let mut failure_counter = 0;
-        while let Ok(sample) = subscriber.recv_async().await {
+        loop {
+            let sample = subscriber
+                .recv_async()
+                .await
+                .expect("All senders have dropped.");
             let metadata = extract_metadata(sample.key_expr().as_str());
             let topic_kind = metadata["action"].as_str();
             if ["success", "failure"].contains(&topic_kind) {

--- a/tests/extra/python/agent_test.py
+++ b/tests/extra/python/agent_test.py
@@ -29,7 +29,7 @@ async def verify(group, pod_job_count):
 
     with zenoh.open(zenoh.Config()) as session:
         with session.declare_subscriber(
-            f"group/{group}/success/pod_job/**", count
+            f"**/action/success/**/group/{group}/**/topic/pod_job/**", count
         ) as subscriber:
             await asyncio.sleep(20)  # wait for results
 


### PR DESCRIPTION
## Features
- Localize zenoh key expression structure to a single builder for both pub/sub (see `make_key_expr`). Keys are alphabetically sorted in key expression.
- Relax structure to be mostly self-describing. This means that the builder structure is minimal and the caller is free to add as much context as necessary via `metadata`.
- When in sub mode, key are delimited by wildcards to allow room to grow. The result is a key expression parsing logic that will be backward compatible with future releases provided we primarily add new keys in the future. Renames will present backward incompatibility but that is somewhat expected. Therefore to avoid this, we should try to pick good key names that we don't expect to rename in the future.
- Eliminate the need to maintain an agent regex and the capture struct i.e. `EventMetadata`.

## Tests
- Add a `default` and a `test` feature. It is only allowed to enable one of them at a time.
  - Default (which is the default feature) will not expose any part of the private API in `core`.
  - Test will expose some portion of `core`. This is useful when integration tests need access to `core`.

## Docs
- Add note about using `git worktree`

## Housekeeping
- Simplify errors related to `None` values to a single `MissingInfo` error. The `details` field can be used to elaborate on what is missing and provide a hint to API user.
- Clean up some of the `while` loops that silenced certain error states.